### PR TITLE
chore: rename org_name to backend_id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
           GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-          GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
+          GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
         run: go test ./internal/provider -v -timeout 30m
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           TF_ACC: 1
           GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
-          GROUNDCOVER_ORG_NAME: ${{ secrets.GROUNDCOVER_ORG_NAME }}
+          GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_ORG_NAME }}
           GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
         run: go test ./internal/provider -v -timeout 30m
       - name: Import GPG key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
           GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-          GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
+          GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
         run: go test ./internal/provider -v -timeout 30m
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
           GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-          GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
+          GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
         run: go test ./internal/provider -v -timeout 30m
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           TF_ACC: 1
           GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
-          GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_ORG_NAME }}
+          GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
           GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
         run: go test ./internal/provider -v -timeout 30m
       - name: Import GPG key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
         GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
         GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-        GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
+        GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
       run: |
         echo "✅ Running acceptance tests with available secrets..."
         go test ./internal/provider -v -timeout 30m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Check if secrets are available
       id: check-secrets
       run: |
-        if [ -n "${{ secrets.GROUNDCOVER_API_KEY }}" ] && [ -n "${{ secrets.GROUNDCOVER_ORG_NAME }}" ]; then
+        if [ -n "${{ secrets.GROUNDCOVER_API_KEY }}" ] && [ -n "${{ secrets.GROUNDCOVER_BACKEND_ID }}" ]; then
           echo "secrets-available=true" >> $GITHUB_OUTPUT
         else
           echo "secrets-available=false" >> $GITHUB_OUTPUT
@@ -88,7 +88,7 @@ jobs:
         TF_ACC: 1
         GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
         GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
-        GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_ORG_NAME }}
+        GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
         GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
       run: |
         echo "✅ Running acceptance tests with available secrets..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         TF_ACC: 1
         GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
         GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
-        GROUNDCOVER_ORG_NAME: ${{ secrets.GROUNDCOVER_ORG_NAME }}
+        GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_ORG_NAME }}
         GROUNDCOVER_CLOUD_ORG_NAME: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
       run: |
         echo "✅ Running acceptance tests with available secrets..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
         GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
         GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-        GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
+        GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
       run: |
         echo "✅ Running acceptance tests with available secrets..."
         go test ./internal/provider -v -timeout 30m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         GROUNDCOVER_API_KEY: ${{ secrets.GROUNDCOVER_API_KEY }}
         GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
         GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
-        GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
+        GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_CLOUD_ORG_NAME }}
       run: |
         echo "✅ Running acceptance tests with available secrets..."
         go test ./internal/provider -v -timeout 30m

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ export GROUNDCOVER_API_URL="https://api.main.groundcover.com/"
 export GROUNDCOVER_BACKEND_ID="your-backend-id"
 # export GROUNDCOVER_ORG_NAME="your-org-name"  # deprecated: use GROUNDCOVER_BACKEND_ID
 
-# For ingestion key tests (requires cloud backend):
-export GROUNDCOVER_CLOUD_ORG_NAME="your-cloud-org-name"
+# For ingestion key tests (requires in-cloud backend):
+export GROUNDCOVER_INCLOUD_BACKEND_ID="your-in-cloud-backend-id"
 ```
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To use this provider locally before it is published to the Terraform Registry, f
 
           # Base URL is optional, defaults to api.groundcover.com in the provider code
           api_url = "https://api.main.groundcover.com" # defaults to https://api.groundcover.com
-          org_name = "groundcover"                     # your organization ID as provided in the installation
+          backend_id = "groundcover"                   # Your Backend ID can be found in the groundcover UI under Settings->Access->API Keys
+          # org_name = "groundcover"                   # deprecated: use backend_id instead
         }
 
         # (Optional but recommended) Define input variables
@@ -157,15 +158,17 @@ Configure the groundcover provider in your Terraform configuration:
 
 ```hcl
 provider "groundcover" {
-  # api_key  = "YOUR_API_KEY" # Required
-  # base_url = "https://api.your-instance.groundcover.com" # Optional
+  # api_key    = "YOUR_API_KEY" # Required
+  # backend_id = "YOUR_BACKEND_ID" # Required - can be found in the groundcover UI under Settings->Access->API Keys
+  # api_url    = "https://api.your-instance.groundcover.com" # Optional
 }
 ```
 
 ### Arguments
 
-*   `api_key` (String, Required, Sensitive): Your groundcover API key. It is strongly recommended to configure this using the `TF_VAR_groundcover_api_key` environment variable rather than hardcoding it.
-*   `base_url` (String, Optional): The base URL for the groundcover API. Defaults to `api.groundcover.com` if not specified.
+*   `api_key` (String, Required, Sensitive): Your groundcover API key. It is strongly recommended to configure this using the `GROUNDCOVER_API_KEY` environment variable rather than hardcoding it.
+*   `backend_id` (String, Required): Your groundcover Backend ID. Can be found in the groundcover UI under Settings->Access->API Keys. Can also be set via the `GROUNDCOVER_BACKEND_ID` environment variable.
+*   `api_url` (String, Optional): The base URL for the groundcover API. Defaults to `https://api.groundcover.com` if not specified. Can also be set via the `GROUNDCOVER_API_URL` environment variable.
 
 ## Testing
 
@@ -178,7 +181,8 @@ Set the required environment variables:
 ```bash
 export GROUNDCOVER_API_KEY="your-api-key-here"
 export GROUNDCOVER_API_URL="https://api.main.groundcover.com/"
-export GROUNDCOVER_ORG_NAME="your-org-name"
+export GROUNDCOVER_BACKEND_ID="your-backend-id"
+# export GROUNDCOVER_ORG_NAME="your-org-name"  # deprecated: use GROUNDCOVER_BACKEND_ID
 
 # For ingestion key tests (requires cloud backend):
 export GROUNDCOVER_CLOUD_ORG_NAME="your-cloud-org-name"

--- a/examples/resources/groundcover_apikey/resource.tf
+++ b/examples/resources/groundcover_apikey/resource.tf
@@ -12,9 +12,9 @@ terraform {
 provider "groundcover" {
   # Configure API key and Org Name via environment variables
   # export TF_VAR_groundcover_api_key="YOUR_API_KEY"
-  # export TF_VAR_groundcover_org_name="YOUR_ORG_NAME"
+  # export TF_VAR_groundcover_backend_id="YOUR_BACKEND_ID"
   api_key  = var.groundcover_api_key
-  org_name = var.groundcover_org_name
+  backend_id = var.groundcover_backend_id
   # api_url = "..." # Optional: Override default API URL
 }
 
@@ -24,9 +24,9 @@ variable "groundcover_api_key" {
   sensitive   = true
 }
 
-variable "groundcover_org_name" {
+variable "groundcover_backend_id" {
   type        = string
-  description = "Groundcover Organization Name"
+  description = "Groundcover Backend ID"
 }
 
 # Example Policy (required for Service Account)

--- a/examples/resources/groundcover_ingestionkey/resource.tf
+++ b/examples/resources/groundcover_ingestionkey/resource.tf
@@ -12,9 +12,9 @@ terraform {
 provider "groundcover" {
   # Configure API key and Org Name via environment variables
   # export TF_VAR_groundcover_api_key="YOUR_API_KEY"
-  # export TF_VAR_groundcover_org_name="YOUR_ORG_NAME"
+  # export TF_VAR_groundcover_backend_id="YOUR_BACKEND_ID"
   api_key  = var.groundcover_api_key
-  org_name = var.groundcover_org_name
+  backend_id = var.groundcover_backend_id
   # api_url = "..." # Optional: Override default API URL
 }
 
@@ -24,9 +24,9 @@ variable "groundcover_api_key" {
   sensitive   = true
 }
 
-variable "groundcover_org_name" {
+variable "groundcover_backend_id" {
   type        = string
-  description = "Groundcover Organization Name"
+  description = "Groundcover Backend ID"
 }
 
 # Example Ingestion Key

--- a/examples/resources/groundcover_logspipeline/resource.tf
+++ b/examples/resources/groundcover_logspipeline/resource.tf
@@ -12,9 +12,9 @@ terraform {
 provider "groundcover" {
   # Configure API key and Org Name via environment variables
   # export TF_VAR_groundcover_api_key="YOUR_API_KEY"
-  # export TF_VAR_groundcover_org_name="YOUR_ORG_NAME"
+  # export TF_VAR_groundcover_backend_id="YOUR_BACKEND_ID"
   api_key  = var.groundcover_api_key
-  org_name = var.groundcover_org_name
+  backend_id = var.groundcover_backend_id
   # api_url = "..." # Optional: Override default API URL
 }
 
@@ -24,9 +24,9 @@ variable "groundcover_api_key" {
   sensitive   = true
 }
 
-variable "groundcover_org_name" {
+variable "groundcover_backend_id" {
   type        = string
-  description = "Groundcover Organization Name"
+  description = "Groundcover Backend ID"
 }
 
 # Example Logs Pipeline

--- a/examples/resources/groundcover_monitor/resource.tf
+++ b/examples/resources/groundcover_monitor/resource.tf
@@ -12,9 +12,9 @@ terraform {
 provider "groundcover" {
   # Configure API key and Org Name via environment variables
   # export TF_VAR_groundcover_api_key="YOUR_API_KEY"
-  # export TF_VAR_groundcover_org_name="YOUR_ORG_NAME"
+  # export TF_VAR_groundcover_backend_id="YOUR_BACKEND_ID"
   api_key  = var.groundcover_api_key
-  org_name = var.groundcover_org_name
+  backend_id = var.groundcover_backend_id
   # api_url = "..." # Optional: Override default API URL
 }
 
@@ -24,9 +24,9 @@ variable "groundcover_api_key" {
   sensitive   = true
 }
 
-variable "groundcover_org_name" {
+variable "groundcover_backend_id" {
   type        = string
-  description = "Groundcover Organization Name"
+  description = "Groundcover Backend ID"
 }
 
 # Example Monitor: K8s Pod Not Healthy using monitor_yaml

--- a/examples/resources/groundcover_policy/resource.tf
+++ b/examples/resources/groundcover_policy/resource.tf
@@ -5,7 +5,7 @@ provider "groundcover" {
   # Or uncomment and set directly (less secure):
   # api_key = "YOUR_API_KEY_HERE"
 
-  org_name = "groundcover" # your organization ID as provided in the installation
+  backend_id = "groundcover" # your backend ID as provided in the installation
   # Optionally override the base URL (defaults to api.groundcover.com)
   # api_url = "https://api.your-instance.groundcover.com"
 }

--- a/examples/resources/groundcover_serviceaccount/resource.tf
+++ b/examples/resources/groundcover_serviceaccount/resource.tf
@@ -12,9 +12,9 @@ terraform {
 provider "groundcover" {
   # Configure API key and Org Name via environment variables
   # export TF_VAR_groundcover_api_key="YOUR_API_KEY"
-  # export TF_VAR_groundcover_org_name="YOUR_ORG_NAME"
+  # export TF_VAR_groundcover_backend_id="YOUR_BACKEND_ID"
   api_key  = var.groundcover_api_key
-  org_name = var.groundcover_org_name
+  backend_id = var.groundcover_backend_id
   # api_url = "..." # Optional: Override default API URL
 }
 
@@ -24,9 +24,9 @@ variable "groundcover_api_key" {
   sensitive   = true
 }
 
-variable "groundcover_org_name" {
+variable "groundcover_backend_id" {
   type        = string
-  description = "Groundcover Organization Name"
+  description = "Groundcover Backend ID"
 }
 
 # Example Policy (required for Service Account)

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -136,7 +136,7 @@ func NewSdkClientWrapper(ctx context.Context, baseURLStr, apiKey, backendID stri
 		return nil, errors.New("GROUNDCOVER_API_KEY (api_key) environment variable or provider config is required")
 	}
 	if backendID == "" {
-		return nil, errors.New("GROUNDCOVER_ORG_NAME (org_name) environment variable or provider config is required")
+		return nil, errors.New("GROUNDCOVER_BACKEND_ID (backend_id) environment variable or provider config is required")
 	}
 
 	userEnabledDebug := os.Getenv("TF_LOG") == "debug"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -25,7 +25,7 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GROUNDCOVER_API_KEY"); v == "" {
 		t.Fatal("GROUNDCOVER_API_KEY must be set for acceptance tests")
 	}
-	if v := os.Getenv("GROUNDCOVER_ORG_NAME"); v == "" {
-		t.Fatal("GROUNDCOVER_ORG_NAME must be set for acceptance tests")
+	if v := os.Getenv("GROUNDCOVER_BACKEND_ID"); v == "" {
+		t.Fatal("GROUNDCOVER_BACKEND_ID must be set for acceptance tests")
 	}
 }

--- a/internal/provider/resource_apikey_test.go
+++ b/internal/provider/resource_apikey_test.go
@@ -150,7 +150,7 @@ func testAccCheckApiKeyResourceDisappears(n string) resource.TestCheckFunc {
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_ORG_NAME")
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID")
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"

--- a/internal/provider/resource_ingestionkey_test.go
+++ b/internal/provider/resource_ingestionkey_test.go
@@ -26,7 +26,7 @@ func TestAccIngestionKeyResource(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckIngestionKey(t)
 		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithCloudOrg(t),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithInCloudBackend(t),
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -66,7 +66,7 @@ func TestAccIngestionKeyResource_disappears(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckIngestionKey(t)
 		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithCloudOrg(t),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithInCloudBackend(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIngestionKeyResourceConfig(name),
@@ -120,7 +120,7 @@ func testAccCheckIngestionKeyResourceDisappears(n string) resource.TestCheckFunc
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID") // Use current backend ID (which should be set to cloud org during test)
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID") // Use current backend ID (which should be set to in-cloud backend during test)
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"
@@ -158,29 +158,29 @@ func testAccPreCheckIngestionKey(t *testing.T) {
 	if v := os.Getenv("GROUNDCOVER_API_KEY"); v == "" {
 		t.Fatal("GROUNDCOVER_API_KEY must be set for acceptance tests")
 	}
-	if v := os.Getenv("GROUNDCOVER_CLOUD_ORG_NAME"); v == "" {
-		t.Skip("Ingestion key tests require GROUNDCOVER_CLOUD_ORG_NAME env var for cloud backend - skipping")
+	if v := os.Getenv("GROUNDCOVER_INCLOUD_BACKEND_ID"); v == "" {
+		t.Skip("Ingestion key tests require GROUNDCOVER_INCLOUD_BACKEND_ID env var for in-cloud backend - skipping")
 	}
 }
 
-// testAccProtoV6ProviderFactoriesWithCloudOrg creates provider factories that use the cloud organization
-func testAccProtoV6ProviderFactoriesWithCloudOrg(t *testing.T) map[string]func() (tfprotov6.ProviderServer, error) {
+// testAccProtoV6ProviderFactoriesWithInCloudBackend creates provider factories that use the in-cloud backend
+func testAccProtoV6ProviderFactoriesWithInCloudBackend(t *testing.T) map[string]func() (tfprotov6.ProviderServer, error) {
 	// Skip if not running acceptance tests
 	if os.Getenv("TF_ACC") == "" {
 		return testAccProtoV6ProviderFactories
 	}
 
-	// Temporarily override GROUNDCOVER_BACKEND_ID with the cloud org name
-	cloudOrgName := os.Getenv("GROUNDCOVER_CLOUD_ORG_NAME")
-	if cloudOrgName == "" {
-		t.Fatal("GROUNDCOVER_CLOUD_ORG_NAME must be set for ingestion key tests")
+	// Temporarily override GROUNDCOVER_BACKEND_ID with the in-cloud backend ID
+	inCloudBackendId := os.Getenv("GROUNDCOVER_INCLOUD_BACKEND_ID")
+	if inCloudBackendId == "" {
+		t.Fatal("GROUNDCOVER_INCLOUD_BACKEND_ID must be set for ingestion key tests")
 	}
 
 	// Store original value to restore later
 	originalBackendID := os.Getenv("GROUNDCOVER_BACKEND_ID")
 
-	// Set the cloud org name and set up cleanup ONCE for the entire test
-	if err := os.Setenv("GROUNDCOVER_BACKEND_ID", cloudOrgName); err != nil {
+	// Set the in-cloud backend ID and set up cleanup ONCE for the entire test
+	if err := os.Setenv("GROUNDCOVER_BACKEND_ID", inCloudBackendId); err != nil {
 		t.Fatalf("Failed to set GROUNDCOVER_BACKEND_ID: %v", err)
 	}
 	t.Cleanup(func() {

--- a/internal/provider/resource_ingestionkey_test.go
+++ b/internal/provider/resource_ingestionkey_test.go
@@ -120,7 +120,7 @@ func testAccCheckIngestionKeyResourceDisappears(n string) resource.TestCheckFunc
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_ORG_NAME") // Use current org name (which should be set to cloud org during test)
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID") // Use current backend ID (which should be set to cloud org during test)
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"
@@ -170,27 +170,27 @@ func testAccProtoV6ProviderFactoriesWithCloudOrg(t *testing.T) map[string]func()
 		return testAccProtoV6ProviderFactories
 	}
 
-	// Temporarily override GROUNDCOVER_ORG_NAME with the cloud org name
+	// Temporarily override GROUNDCOVER_BACKEND_ID with the cloud org name
 	cloudOrgName := os.Getenv("GROUNDCOVER_CLOUD_ORG_NAME")
 	if cloudOrgName == "" {
 		t.Fatal("GROUNDCOVER_CLOUD_ORG_NAME must be set for ingestion key tests")
 	}
 
 	// Store original value to restore later
-	originalOrgName := os.Getenv("GROUNDCOVER_ORG_NAME")
+	originalBackendID := os.Getenv("GROUNDCOVER_BACKEND_ID")
 
 	// Set the cloud org name and set up cleanup ONCE for the entire test
-	if err := os.Setenv("GROUNDCOVER_ORG_NAME", cloudOrgName); err != nil {
-		t.Fatalf("Failed to set GROUNDCOVER_ORG_NAME: %v", err)
+	if err := os.Setenv("GROUNDCOVER_BACKEND_ID", cloudOrgName); err != nil {
+		t.Fatalf("Failed to set GROUNDCOVER_BACKEND_ID: %v", err)
 	}
 	t.Cleanup(func() {
-		if originalOrgName != "" {
-			if err := os.Setenv("GROUNDCOVER_ORG_NAME", originalOrgName); err != nil {
-				t.Errorf("Failed to restore GROUNDCOVER_ORG_NAME: %v", err)
+		if originalBackendID != "" {
+			if err := os.Setenv("GROUNDCOVER_BACKEND_ID", originalBackendID); err != nil {
+				t.Errorf("Failed to restore GROUNDCOVER_BACKEND_ID: %v", err)
 			}
 		} else {
-			if err := os.Unsetenv("GROUNDCOVER_ORG_NAME"); err != nil {
-				t.Errorf("Failed to unset GROUNDCOVER_ORG_NAME: %v", err)
+			if err := os.Unsetenv("GROUNDCOVER_BACKEND_ID"); err != nil {
+				t.Errorf("Failed to unset GROUNDCOVER_BACKEND_ID: %v", err)
 			}
 		}
 	})

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -225,7 +225,7 @@ func testAccCheckMonitorResourceDisappears(n string) resource.TestCheckFunc {
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_ORG_NAME")
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID")
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -180,7 +180,7 @@ func testAccCheckPolicyResourceDisappears(n string) resource.TestCheckFunc {
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_ORG_NAME")
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID")
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"

--- a/internal/provider/resource_serviceaccount_test.go
+++ b/internal/provider/resource_serviceaccount_test.go
@@ -171,7 +171,7 @@ func testAccCheckServiceAccountResourceDisappears(n string) resource.TestCheckFu
 
 		// Get environment variables for client configuration
 		apiKey := os.Getenv("GROUNDCOVER_API_KEY")
-		orgName := os.Getenv("GROUNDCOVER_ORG_NAME")
+		orgName := os.Getenv("GROUNDCOVER_BACKEND_ID")
 		apiURL := os.Getenv("GROUNDCOVER_API_URL")
 		if apiURL == "" {
 			apiURL = "https://api.groundcover.io"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation and example configurations to use the new backend ID parameter instead of the deprecated organization name.
  * Clarified environment variable usage and updated testing instructions to reflect the new naming conventions.

* **New Features**
  * Introduced support for a new backend ID parameter in provider configuration, with backwards compatibility for the old organization name.

* **Refactor**
  * Updated provider schema and internal logic to prefer backend ID, marking organization name as deprecated but still supported.

* **Style**
  * Improved error messages and logging to reference backend ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->