### PR TITLE
fix: docs and exampels linting and misalignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.3.0
 
 * Added advanced data scope support for policy resource, enabling per-data-type filtering rules (logs, metrics, traces, events, workloads)
-* Improved docs and examples for monitors, dashbaords and data integrations
+* Improved docs and examples for monitors, dashboards and data integrations
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.0
 
 * Added advanced data scope support for policy resource, enabling per-data-type filtering rules (logs, metrics, traces, events, workloads)
+* Improved docs and examples for monitors, dashbaords and data integrations
 
 ## 1.2.0
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -180,9 +180,14 @@ output "metrics_dashboard_status" {
   value       = groundcover_dashboard.metrics_dashboard.status
 }
 
-output "simple_dashboard_owner" {
-  description = "The owner of the simple dashboard"
-  value       = groundcover_dashboard.simple_dashboard.owner
+output "simple_dashboard_id" {
+  description = "The UUID of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.id
+}
+
+output "simple_dashboard_status" {
+  description = "The status of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.status
 }
 ```
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -175,9 +175,9 @@ output "metrics_dashboard_id" {
   value       = groundcover_dashboard.metrics_dashboard.id
 }
 
-output "metrics_dashboard_status" {
-  description = "The status of the metrics dashboard"
-  value       = groundcover_dashboard.metrics_dashboard.status
+output "metrics_dashboard_owner" {
+  description = "The owner of the metrics dashboard"
+  value       = groundcover_dashboard.metrics_dashboard.owner
 }
 
 output "simple_dashboard_id" {
@@ -185,9 +185,9 @@ output "simple_dashboard_id" {
   value       = groundcover_dashboard.simple_dashboard.id
 }
 
-output "simple_dashboard_status" {
-  description = "The status of the simple dashboard"
-  value       = groundcover_dashboard.simple_dashboard.status
+output "simple_dashboard_owner" {
+  description = "The owner of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.owner
 }
 ```
 

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -3,12 +3,12 @@
 page_title: "groundcover_dataintegration Resource - groundcover"
 subcategory: ""
 description: |-
-  DataIntegration resource for managing data integrations with external services.
+  DataIntegration resource for managing groundcover's integrations with external services such as cloud providers, databases and more. This resource is composed of general metadata on the integration and a specific configuration per data source. Navigate to the relevant nested schema according to your specific needs.
 ---
 
 # groundcover_dataintegration (Resource)
 
-DataIntegration resource for managing data integrations with external services.
+DataIntegration resource for managing groundcover's integrations with external services such as cloud providers, databases and more. This resource is composed of general metadata on the integration and a specific configuration per data source. Navigate to the relevant nested schema according to your specific needs.
 
 ## Example Usage
 
@@ -29,13 +29,15 @@ provider "groundcover" {
 }
 
 # Example: CloudWatch DataIntegration
+# For a full list of supported AWS metrics and statistics, visit the official CloudWatch documentation:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html
 resource "groundcover_dataintegration" "cloudwatch_example" {
   type = "cloudwatch"
   config = jsonencode({
     name      = "test-cloudwatch"
     version   = 1
     stsRegion = "us-east-1"
-    regions   = ["us-east-1"]
+    regions   = ["us-east-1", "us-east-2"]
     roleArn   = "arn:aws:iam::123456789012:role/test-role"
     awsMetrics = [
       {
@@ -44,21 +46,13 @@ resource "groundcover_dataintegration" "cloudwatch_example" {
           {
             name       = "CPUUtilization"
             statistics = ["Average"]
-            period     = 300
-            length     = 300
-            nullAsZero = false
           }
         ]
       }
     ]
-    apiConcurrencyLimits = {
-      listMetrics         = 3
-      getMetricData       = 5
-      getMetricStatistics = 5
-      listInventory       = 10
+    labelSettings = {
+      extraLabels = ["env", "prod"]
     }
-    withContextTagsOnInfoMetrics = false
-    withInventoryDiscovery       = false
   })
   is_paused = false
 }

--- a/examples/resources/groundcover_dashboard/resource.tf
+++ b/examples/resources/groundcover_dashboard/resource.tf
@@ -29,39 +29,148 @@ variable "groundcover_backend_id" {
   description = "Groundcover Backend ID"
 }
 
-# Example Dashboard: Kubernetes Monitoring Dashboard
-resource "groundcover_dashboard" "kubernetes_monitoring_dashboard" {
-    name             = "Kubernetes Monitoring Dashboard"
-    description      = "Example dashboard showing Kubernetes monitoring metrics"
+# Example Dashboard: Basic metrics dashboard
+resource "groundcover_dashboard" "metrics_dashboard" {
+  name        = "Terraform Example - Metrics Dashboard"
+  description = "Example dashboard showing system metrics"
+  team        = "platform"
 
-    # Dashboard preset contains the JSON configuration with escaped quotes
-    preset           = "{\"widgets\":[{\"id\":\"A\",\"type\":\"widget\",\"name\":\"Persistent Volume Storages\",\"queries\":[{\"id\":\"A\",\"expr\":\"sum(rate(groundcover_network_rx_bytes_total{cluster=\\\"$clusters\\\"})) by (node_name)\",\"dataType\":\"metrics\",\"editorMode\":\"editor\"}],\"visualizationConfig\":{\"type\":\"table\"}},{\"id\":\"E\",\"type\":\"widget\",\"name\":\"Node Disk Usage\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_node_rt_disk_space_used_percent{cluster=\\\"$clusters\\\",node_name=\\\"$nodes\\\"}) by (node_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\"}},{\"id\":\"H\",\"type\":\"widget\",\"name\":\"Node CPU Usage %\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_node_rt_cpu_usage_percent{cluster=\\\"$clusters\\\",node_name=\\\"$nodes\\\"}) by (node_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\"}},{\"id\":\"I\",\"type\":\"widget\",\"name\":\"Node Memory Usage % (copy)\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_node_rt_mem_used_percent{cluster=\\\"$clusters\\\",node_name=\\\"$nodes\\\"}) by (node_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\"}},{\"id\":\"F\",\"type\":\"widget\",\"name\":\"Container CPU Usage\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_container_cpu_usage_rate_millis{cluster=\\\"$clusters\\\"}) by (container_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\",\"selectedChartType\":\"stackedBar\"}},{\"id\":\"B\",\"type\":\"widget\",\"name\":\"Container CPU Usage\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_container_memory_working_set_bytes{cluster=\\\"$clusters\\\"}) by (container_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\",\"selectedChartType\":\"line\",\"selectedUnit\":\"Number\",\"yAxis\":{\"zero\":false}}},{\"id\":\"G\",\"type\":\"widget\",\"name\":\"Container Network Throughput (Rx)\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(rate(groundcover_network_rx_bytes_total{})) by (container_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"table\",\"selectedUnit\":\"Bytes/sec\"}},{\"id\":\"J\",\"type\":\"widget\",\"name\":\"Container Network Througput (Rx)\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(rate(groundcover_network_rx_bytes_total{})) by (container_name)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\"}},{\"id\":\"K\",\"type\":\"section\",\"name\":\"Container Resource Usage\",\"color\":\"gray\"},{\"id\":\"L\",\"type\":\"section\",\"name\":\"Node Resource Usage\",\"color\":\"gray\"}],\"layout\":[{\"id\":\"K\",\"x\":12,\"y\":0,\"w\":12,\"h\":29,\"minH\":2,\"children\":[{\"id\":\"E\",\"x\":0,\"y\":2,\"w\":12,\"minH\":8},{\"id\":\"F\",\"x\":0,\"y\":10,\"w\":12,\"h\":10,\"minH\":8},{\"id\":\"G\",\"x\":0,\"y\":20,\"w\":6,\"minH\":8},{\"id\":\"J\",\"x\":6,\"y\":20,\"w\":6,\"minH\":8}]},{\"id\":\"L\",\"x\":0,\"y\":0,\"w\":12,\"h\":29,\"minH\":2,\"children\":[{\"id\":\"H\",\"x\":0,\"y\":2,\"w\":6,\"minH\":8},{\"id\":\"I\",\"x\":6,\"y\":2,\"w\":6,\"minH\":8},{\"id\":\"B\",\"x\":0,\"y\":10,\"w\":12,\"minH\":8},{\"id\":\"A\",\"x\":0,\"y\":18,\"w\":12,\"h\":10,\"minH\":8}]}],\"duration\":\"Last 6 hours\",\"variables\":[{\"kind\":\"list\",\"spec\":{\"variableName\":\"nodes\",\"datasource\":{\"kind\":\"metrics\",\"metric\":\"groundcover_node_rt_m_cpu_usage\",\"key\":\"node_name\"},\"values\":{\"default\":[\"*\"]}}},{\"kind\":\"list\",\"spec\":{\"variableName\":\"clusters\",\"datasource\":{\"kind\":\"metrics\",\"metric\":\"groundcover_node_rt_m_cpu_usage\",\"key\":\"cluster\"},\"values\":{\"default\":[\"*\"]}}},{\"kind\":\"list\",\"spec\":{\"variableName\":\"containers\",\"datasource\":{\"kind\":\"metrics\",\"metric\":\"groundcover_container_cpu_usage_rate_millis\",\"key\":\"container_name\"},\"values\":{\"default\":[\"*\"]}}}],\"spec\":{\"layoutType\":\"ordered\"},\"schemaVersion\":6}"
-  }
+  # Dashboard preset contains the JSON configuration
+  preset = jsonencode({
+    duration = "Last 1 hour"
+    layout = [
+      {
+        id   = "A"
+        x    = 0
+        y    = 0
+        w    = 12
+        h    = 4
+        minH = 2
+      },
+      {
+        id   = "B"
+        x    = 0
+        y    = 4
+        w    = 6
+        h    = 4
+        minH = 2
+      },
+      {
+        id   = "C"
+        x    = 6
+        y    = 4
+        w    = 6
+        h    = 4
+        minH = 2
+      }
+    ]
+    widgets = [
+      {
+        id   = "A"
+        type = "widget"
+        name = "CPU Usage"
+        queries = [
+          {
+            id         = "A"
+            expr       = "avg(rate(container_cpu_usage_seconds_total[5m])) * 100"
+            dataType   = "metrics"
+            step       = null
+            editorMode = "builder"
+          }
+        ]
+        visualizationConfig = {
+          type = "time-series"
+        }
+      },
+      {
+        id   = "B"
+        type = "widget"
+        name = "Memory Usage"
+        queries = [
+          {
+            id         = "B"
+            expr       = "avg(container_memory_usage_bytes)"
+            dataType   = "metrics"
+            step       = null
+            editorMode = "builder"
+          }
+        ]
+        visualizationConfig = {
+          type = "gauge"
+        }
+      },
+      {
+        id   = "C"
+        type = "text"
+        html = "<h3>System Metrics</h3><p>This dashboard shows key system metrics including CPU and memory usage.</p>"
+      }
+    ]
+    variables     = {}
+    schemaVersion = 3
+  })
 
-# Example Dashboard: LLM Observability Dashboard
-resource "groundcover_dashboard" "llm_observability" {
-    name             = "LLM Observability"
-    description      = "Example dashboard overviewing OpenAI and Anthropic"
-    # Dashboard preset contains the JSON configuration with escaped quotes
-    preset           = "{\"widgets\":[{\"id\":\"B\",\"type\":\"widget\",\"name\":\"Total LLM Calls\",\"queries\":[{\"id\":\"A\",\"expr\":\"span_type:openai span_type:anthropic | stats by(span_type) count() count_all_result | sort by (count_all_result desc) | limit 5\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\"}},{\"id\":\"D\",\"type\":\"widget\",\"name\":\"LLM Calls Rate\",\"queries\":[{\"id\":\"A\",\"expr\":\"sum(rate(groundcover_resource_total_counter{type=~\\\"openai|anthropic\\\",status_code=\\\"ok\\\"})) by (gen_ai_request_model)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\",\"selectedChartType\":\"stackedBar\"}},{\"id\":\"E\",\"type\":\"widget\",\"name\":\"Average LLM Response Time\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_resource_latency_seconds{type=~\\\"openai|anthropic\\\"}) by (type)\",\"dataType\":\"metrics\",\"step\":\"disabled\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\",\"step\":\"disabled\",\"selectedUnit\":\"Seconds\"}},{\"id\":\"A\",\"type\":\"widget\",\"name\":\"Total LLM Tokens Used\",\"queries\":[{\"id\":\"A\",\"expr\":\"span_type:openai span_type:anthropic | stats by(span_type) sum(gen_ai.response.usage.total_tokens) sum_result | sort by (sum_result desc) | limit 5\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\",\"step\":\"disabled\"}},{\"id\":\"C\",\"type\":\"widget\",\"name\":\"AVG Input Tokens Per LLM Call \",\"queries\":[{\"id\":\"A\",\"expr\":\"span_type:openai OR span_type:anthropic | stats by(span_type) avg(gen_ai.response.usage.input_tokens) avg_result | sort by (avg_result desc) | limit 5\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\"}},{\"id\":\"F\",\"type\":\"widget\",\"name\":\"AVG Output Tokens Per LLM Call \",\"queries\":[{\"id\":\"A\",\"expr\":\"span_type:openai OR span_type:anthropic | stats by(span_type) avg(gen_ai.response.usage.output_tokens) avg_result | sort by (avg_result desc) | limit 5\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\",\"step\":\"disabled\"}},{\"id\":\"G\",\"type\":\"widget\",\"name\":\"Top Used Models\",\"queries\":[{\"id\":\"A\",\"expr\":\"span_type:openai OR span_type:anthropic | stats by(gen_ai.request.model) count() count_all_result | sort by (count_all_result desc) | limit 100\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"bar\",\"step\":\"disabled\"}},{\"id\":\"H\",\"type\":\"widget\",\"name\":\"Total LLM Errors \",\"queries\":[{\"id\":\"A\",\"expr\":\"(span_type:openai OR span_type:anthropic) status:error | stats by(span_type) count() count_all_result | sort by (count_all_result desc) | limit 1\",\"dataType\":\"traces\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"stat\"}},{\"id\":\"I\",\"type\":\"widget\",\"name\":\"AVG TTFT Over Time by Model\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_workload_latency_seconds{gen_ai_system=~\\\"openai|anthropic\\\",quantile=\\\"0.50\\\"}) by (gen_ai_request_model)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\",\"selectedChartType\":\"line\",\"selectedUnit\":\"Seconds\"}},{\"id\":\"J\",\"type\":\"widget\",\"name\":\"Avg Output Tokens Per Second by Model\",\"queries\":[{\"id\":\"A\",\"expr\":\"avg(groundcover_gen_ai_response_usage_output_tokens{}) by (gen_ai_request_model)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"},{\"id\":\"B\",\"expr\":\"avg(groundcover_workload_latency_seconds{quantile=\\\"0.50\\\"}) by (gen_ai_request_model)\",\"dataType\":\"metrics\",\"editorMode\":\"builder\"},{\"id\":\"formula-A\",\"expr\":\"A / B\",\"dataType\":\"metrics-formula\",\"editorMode\":\"builder\"}],\"visualizationConfig\":{\"type\":\"time-series\",\"selectedUnit\":\"Number\"}}],\"layout\":[{\"id\":\"B\",\"x\":0,\"y\":0,\"w\":4,\"h\":12,\"minH\":8},{\"id\":\"D\",\"x\":0,\"y\":48,\"w\":24,\"h\":12,\"minH\":8},{\"id\":\"E\",\"x\":8,\"y\":0,\"w\":8,\"h\":12,\"minH\":8},{\"id\":\"A\",\"x\":16,\"y\":0,\"w\":8,\"h\":12,\"minH\":8},{\"id\":\"C\",\"x\":0,\"y\":36,\"w\":8,\"h\":12,\"minH\":8},{\"id\":\"F\",\"x\":8,\"y\":36,\"w\":8,\"h\":12,\"minH\":8},{\"id\":\"G\",\"x\":16,\"y\":36,\"w\":8,\"h\":12,\"minH\":8},{\"id\":\"H\",\"x\":4,\"y\":0,\"w\":4,\"h\":12,\"minH\":8},{\"id\":\"I\",\"x\":0,\"y\":24,\"w\":24,\"h\":12,\"minH\":8},{\"id\":\"J\",\"x\":0,\"y\":6,\"w\":24,\"h\":12,\"minH\":8}],\"duration\":\"Last 15 minutes\",\"variables\":[],\"spec\":{\"layoutType\":\"ordered\"},\"schemaVersion\":6}"
-  }
-
-output "kubernetes_monitoring_dashboard_id" {
-  description = "The UUID of the Kubernetes monitoring dashboard"
-  value       = groundcover_dashboard.kubernetes_monitoring_dashboard.id
 }
 
-output "kubernetes_monitoring_dashboard_status" {
-  description = "The status of the Kubernetes monitoring dashboard"
-  value       = groundcover_dashboard.kubernetes_monitoring_dashboard.status
+# Example Dashboard: Simple monitoring dashboard
+resource "groundcover_dashboard" "simple_dashboard" {
+  name = "Simple Dashboard"
+
+  preset = jsonencode({
+    duration = "Last 30 minutes"
+    layout = [
+      {
+        id   = "widget1"
+        x    = 0
+        y    = 0
+        w    = 12
+        h    = 6
+        minH = 3
+      }
+    ]
+    widgets = [
+      {
+        id   = "widget1"
+        type = "widget"
+        name = "Request Rate"
+        queries = [
+          {
+            id         = "query1"
+            expr       = "sum(rate(http_requests_total[5m]))"
+            dataType   = "metrics"
+            step       = null
+            editorMode = "code"
+          }
+        ]
+        visualizationConfig = {
+          type = "time-series"
+          config = {
+            showLegend = true
+            unit       = "ops"
+          }
+        }
+      }
+    ]
+    variables     = {}
+    schemaVersion = 3
+  })
 }
 
-output "llm_observability_dashboard_id" {
-  description = "The UUID of the LLM observability dashboard"
-  value       = groundcover_dashboard.llm_observability.id
+output "metrics_dashboard_id" {
+  description = "The UUID of the metrics dashboard"
+  value       = groundcover_dashboard.metrics_dashboard.id
 }
 
-output "llm_observability_dashboard_status" {
-  description = "The status of the LLM observability dashboard"
-  value       = groundcover_dashboard.llm_observability.status
+output "metrics_dashboard_status" {
+  description = "The status of the metrics dashboard"
+  value       = groundcover_dashboard.metrics_dashboard.status
+}
+
+output "simple_dashboard_id" {
+  description = "The UUID of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.id
+}
+
+output "simple_dashboard_status" {
+  description = "The status of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.status
 }

--- a/examples/resources/groundcover_dashboard/resource.tf
+++ b/examples/resources/groundcover_dashboard/resource.tf
@@ -160,9 +160,9 @@ output "metrics_dashboard_id" {
   value       = groundcover_dashboard.metrics_dashboard.id
 }
 
-output "metrics_dashboard_status" {
-  description = "The status of the metrics dashboard"
-  value       = groundcover_dashboard.metrics_dashboard.status
+output "metrics_dashboard_owner" {
+  description = "The owner of the metrics dashboard"
+  value       = groundcover_dashboard.metrics_dashboard.owner
 }
 
 output "simple_dashboard_id" {
@@ -170,7 +170,7 @@ output "simple_dashboard_id" {
   value       = groundcover_dashboard.simple_dashboard.id
 }
 
-output "simple_dashboard_status" {
-  description = "The status of the simple dashboard"
-  value       = groundcover_dashboard.simple_dashboard.status
+output "simple_dashboard_owner" {
+  description = "The owner of the simple dashboard"
+  value       = groundcover_dashboard.simple_dashboard.owner
 }

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -14,13 +14,15 @@ provider "groundcover" {
 }
 
 # Example: CloudWatch DataIntegration
+# For a full list of supported AWS metrics and statistics, visit the official CloudWatch documentation:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html
 resource "groundcover_dataintegration" "cloudwatch_example" {
   type = "cloudwatch"
   config = jsonencode({
     name      = "test-cloudwatch"
     version   = 1
     stsRegion = "us-east-1"
-    regions   = ["us-east-1"]
+    regions   = ["us-east-1", "us-east-2"]
     roleArn   = "arn:aws:iam::123456789012:role/test-role"
     awsMetrics = [
       {
@@ -29,21 +31,13 @@ resource "groundcover_dataintegration" "cloudwatch_example" {
           {
             name       = "CPUUtilization"
             statistics = ["Average"]
-            period     = 300
-            length     = 300
-            nullAsZero = false
           }
         ]
       }
     ]
-    apiConcurrencyLimits = {
-      listMetrics         = 3
-      getMetricData       = 5
-      getMetricStatistics = 5
-      listInventory       = 10
+    labelSettings = {
+      extraLabels = ["env", "prod"]
     }
-    withContextTagsOnInfoMetrics = false
-    withInventoryDiscovery       = false
   })
   is_paused = false
 }

--- a/internal/provider/resource_dataintegration.go
+++ b/internal/provider/resource_dataintegration.go
@@ -47,7 +47,7 @@ func (r *dataIntegrationResource) Metadata(_ context.Context, req resource.Metad
 
 func (r *dataIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "DataIntegration resource for managing data integrations with external services.",
+		Description: "DataIntegration resource for managing groundcover's integrations with external services such as cloud providers, databases and more. This resource is composed of general metadata on the integration and a specific configuration per data source. Navigate to the relevant nested schema according to your specific needs.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The unique identifier of the data integration configuration.",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Docs updated with clearer examples and expanded data-integration guidance; CloudWatch regions list expanded.
  * Monitor example revised to illustrate a Kubernetes Pod CrashLoopBackOff scenario with updated YAML and evaluation details.
  * Dashboard outputs adjusted to expose dashboard IDs and owners (status output removed) and general wording fixes.

* **Examples**
  * Added a simplified dashboard and a compact metrics dashboard; older example dashboards removed and outputs reorganized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->