### PR TITLE
bertin/cho-4456-add-tf-example-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.5.3
 
+* Added Prometheus static targets, Prometheus target discovery, and MongoDB Atlas examples to data integration resource documentation
 * Improved automatic normalization of monitor YAML to convert single-line pipe syntax to simple strings
 * Improved semantic comparison to ignore formatting differences (trailing newlines, multiline syntax)
 * Added normalization for expression fields to handle multiline formatting differences (e.g., expressions split across lines with trailing spaces vs single-line expressions returned by API)

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -189,7 +189,7 @@ resource "groundcover_dataintegration" "prometheus_discovery_example" {
       url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example"
 
       # Please refer to the groundcover_secret doc on how to create a secret
-      authentication = {
+      authentication = { # Authentication for the discovery endpoint
         basicAuth = {
           username = "prom_user_6909b9ab19480f045c1f2eca"
           password = "secretRef::store::5219731e4bc798eb"
@@ -206,7 +206,7 @@ resource "groundcover_dataintegration" "prometheus_discovery_example" {
       ]
     }
 
-    authentication = {
+    authentication = { # Authentication for scraping discovered targets
       basicAuth = {
         username = "prom_user_6909b9ab19480f045c1f2eca"
         password = "secretRef::store::15e1b4b9c0ce0a45"
@@ -263,7 +263,7 @@ resource "groundcover_dataintegration" "mongodb_atlas_example" {
       url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example/discovery"
 
       # Please refer to the groundcover_secret doc on how to create a secret
-      authentication = {
+      authentication = { # Authentication for the discovery endpoint
         basicAuth = {
           username = "prom_user_6909b9ab19480f045c1f2eca"
           password = "secretRef::store::5219731e4bc798eb"
@@ -280,7 +280,7 @@ resource "groundcover_dataintegration" "mongodb_atlas_example" {
       ]
     }
 
-    authentication = {
+    authentication = { # Authentication for scraping discovered targets
       basicAuth = {
         username = "prom_user_6909b9ab19480f045c1f2eca"
         password = "secretRef::store::15e1b4b9c0ce0a45"

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -104,8 +104,8 @@ resource "groundcover_dataintegration" "prometheus_static_example" {
     name           = "prometheus-static-config"
     scheme         = "https"
     metricsPath    = "/metrics"
-    scrapeInterval = "30s"
-    scrapeTimeout  = "10s"
+    scrapeInterval = 30000000000
+    scrapeTimeout  = 10000000000
 
     staticTargets = [
       "prometheus-target.example.com:9090"

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -95,6 +95,206 @@ resource "groundcover_dataintegration" "azure_example" {
   is_paused = false
 }
 
+# Example: Prometheus Static Targets
+resource "groundcover_dataintegration" "prometheus_static_example" {
+  type = "prometheusscrape"
+  config = jsonencode({
+    version        = 1
+    enabled        = true
+    name           = "prometheus-static-config"
+    scheme         = "https"
+    metricsPath    = "/metrics"
+    scrapeInterval = "30s"
+    scrapeTimeout  = "10s"
+
+    staticTargets = [
+      "prometheus-target.example.com:9090"
+    ]
+
+    exporters = [
+      "prometheus"
+    ]
+
+    metricsRelabels = {
+      # List of regex of metrics to keep. All other metrics will be dropped.
+      keepRegex = [
+        "[*]cpu[*]"
+      ]
+
+      # List of regex of metrics to drop
+      dropRegex = [
+        "DB1[*]"
+      ]
+      raw = <<-EOT
+# additional relabeling rules that can be applied such as adding a prefix
+  - action: labelmap
+    replacement: "groundcover_$1"
+EOT
+    }
+
+    labelSettings = {
+      extraLabels = {
+        env = "prod"
+      }
+    }
+
+    authentication = {
+      basicAuth = {
+        username = "prometheus-user"
+        # refer to groundcover_secret to create a secret
+        password = "secretRef::store::d1fc037f11f8ce58"
+      }
+    }
+  })
+  is_paused = false
+}
+
+# Example: Prometheus HTTPs Target Discovery
+resource "groundcover_dataintegration" "prometheus_discovery_example" {
+  type = "prometheusscrape"
+
+  config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "Target discovery scraping example"
+
+    exporters = [
+      "prometheus"
+    ]
+
+    # Durations are numeric (nanoseconds), preserved as-is
+    scrapeInterval = 30000000000
+    scrapeTimeout  = 10000000000
+
+    metricsPath = "/metrics"
+    scheme      = "http"
+
+    # provide the host details for discovery
+    httpDiscovery = {
+      url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example"
+
+      # Please refer to the groundcover_secret doc on how to create a secret
+      authentication = {
+        basicAuth = {
+          username = "prom_user_6909b9ab19480f045c1f2eca"
+          password = "secretRef::store::5219731e4bc798eb"
+        }
+      }
+    }
+    # Relabeling options on discovered targets. keepRegex - drop all targets which don't comply with this rule. dropRegex - drop all targets which comply with this rule.
+    targetsRelabels = {
+      keepRegex = [
+        ".*shard-00-02.*"
+      ]
+      dropRegex = [
+        ".*shard-00-01.*"
+      ]
+    }
+
+    authentication = {
+      basicAuth = {
+        username = "prom_user_6909b9ab19480f045c1f2eca"
+        password = "secretRef::store::15e1b4b9c0ce0a45"
+      }
+    }
+
+    metricsRelabels = {
+      # List of regex of metrics to keep. All other metrics will be dropped.
+      keepRegex = [
+        "[*]cpu[*]"
+      ]
+      dropRegex = [
+        "DB1[*]"
+      ]
+      raw = <<-EOT
+# additional relabeling rules that can be applied such as adding a prefix
+  - action: labelmap
+    replacement: "groundcover_$1"
+EOT
+    }
+
+    labelSettings = {
+      extraLabels = {
+        env = "prod"
+      }
+    }
+  })
+
+  is_paused = false
+}
+
+# Example: MongoDB Atlas
+resource "groundcover_dataintegration" "mongodb_atlas_example" {
+  type = "mongoatlasscrape"
+
+  config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "MongoDB Atlas example"
+
+    exporters = [
+      "prometheus"
+    ]
+
+    # Durations are numeric (nanoseconds), preserved as-is
+    scrapeInterval = 30000000000
+    scrapeTimeout  = 10000000000
+
+    metricsPath = "/metrics"
+    scheme      = "http"
+
+    # provide the host details for discovery
+    httpDiscovery = {
+      url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example/discovery"
+
+      # Please refer to the groundcover_secret doc on how to create a secret
+      authentication = {
+        basicAuth = {
+          username = "prom_user_6909b9ab19480f045c1f2eca"
+          password = "secretRef::store::5219731e4bc798eb"
+        }
+      }
+    }
+    # Relabeling options on discovered targets. keepRegex - drop all targets which don't comply with this rule. dropRegex - drop all targets which comply with this rule.
+    targetsRelabels = {
+      keepRegex = [
+        ".*shard-00-02.*"
+      ]
+      dropRegex = [
+        ".*shard-00-01.*"
+      ]
+    }
+
+    authentication = {
+      basicAuth = {
+        username = "prom_user_6909b9ab19480f045c1f2eca"
+        password = "secretRef::store::15e1b4b9c0ce0a45"
+      }
+    }
+
+    metricsRelabels = {
+      # List of regex of metrics to keep. All other metrics will be dropped.
+      keepRegex = []
+      dropRegex = [
+        "[*]catalogStats[*]"
+      ]
+      raw = <<-EOT
+# additional relabeling rules that can be applied such as adding a prefix
+  - action: labelmap
+    replacement: "groundcover_$1"
+EOT
+    }
+
+    labelSettings = {
+      extraLabels = {
+        env = "prod"
+      }
+    }
+  })
+
+  is_paused = false
+}
+
 # Output the data integration IDs for reference
 output "cloudwatch_dataintegration_id" {
   description = "The ID of the CloudWatch data integration"
@@ -109,4 +309,19 @@ output "gcpmetrics_dataintegration_id" {
 output "azuremetrics_dataintegration_id" {
   description = "The ID of the Azure Metrics data integration"
   value       = groundcover_dataintegration.azure_example.id
+}
+
+output "prometheus_static_dataintegration_id" {
+  description = "The ID of the Prometheus Static Targets data integration"
+  value       = groundcover_dataintegration.prometheus_static_example.id
+}
+
+output "prometheus_discovery_dataintegration_id" {
+  description = "The ID of the Prometheus Target Discovery data integration"
+  value       = groundcover_dataintegration.prometheus_discovery_example.id
+}
+
+output "mongodb_atlas_dataintegration_id" {
+  description = "The ID of the MongoDB Atlas data integration"
+  value       = groundcover_dataintegration.mongodb_atlas_example.id
 }

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -174,7 +174,7 @@ resource "groundcover_dataintegration" "prometheus_discovery_example" {
       url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example"
 
       # Please refer to the groundcover_secret doc on how to create a secret
-      authentication = {
+      authentication = { # Authentication for the discovery endpoint
         basicAuth = {
           username = "prom_user_6909b9ab19480f045c1f2eca"
           password = "secretRef::store::5219731e4bc798eb"
@@ -191,7 +191,7 @@ resource "groundcover_dataintegration" "prometheus_discovery_example" {
       ]
     }
 
-    authentication = {
+    authentication = { # Authentication for scraping discovered targets
       basicAuth = {
         username = "prom_user_6909b9ab19480f045c1f2eca"
         password = "secretRef::store::15e1b4b9c0ce0a45"
@@ -248,7 +248,7 @@ resource "groundcover_dataintegration" "mongodb_atlas_example" {
       url = "https://cloud.mongodb.com/prometheus/v1.0/groups/example/discovery"
 
       # Please refer to the groundcover_secret doc on how to create a secret
-      authentication = {
+      authentication = { # Authentication for the discovery endpoint
         basicAuth = {
           username = "prom_user_6909b9ab19480f045c1f2eca"
           password = "secretRef::store::5219731e4bc798eb"
@@ -265,7 +265,7 @@ resource "groundcover_dataintegration" "mongodb_atlas_example" {
       ]
     }
 
-    authentication = {
+    authentication = { # Authentication for scraping discovered targets
       basicAuth = {
         username = "prom_user_6909b9ab19480f045c1f2eca"
         password = "secretRef::store::15e1b4b9c0ce0a45"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three new example Terraform configurations: Prometheus static targets, Prometheus HTTP target discovery, and MongoDB Atlas data integrations.
  * Each example demonstrates authentication, relabeling, discovery options, exporters, scrape intervals/timeouts, and label guidance.
  * Added example outputs to expose the created data integration IDs and updated the changelog entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->