### PR TITLE
fix(ingestionkey): correct type field docs to valid SDK values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.1
+
+* Fixed incorrect ingestion key `type` documentation — valid values are `sensor`, `rum`, and `thirdParty` (not `ingestion`)
+* Added acceptance tests for all ingestion key type options (`sensor`, `rum`, `thirdParty`)
+
 ## 1.8.0
 
 * Added traces pipeline resource for configuring traces processing pipelines (singleton resource)

--- a/docs/resources/connected_app.md
+++ b/docs/resources/connected_app.md
@@ -95,9 +95,9 @@ output "pagerduty_app_id" {
 
 ### Required
 
-- `data` (Dynamic, Sensitive) Type-specific configuration. Supports nested structures. For slack-webhook: {url = "https://..."}. For pagerduty: {routing_key = "...", severity_mapping = {critical = "P1", ...}}.
+- `data` (Dynamic, Sensitive) Type-specific configuration. Supports nested structures. For slack-webhook: {url = "https://..."}. For pagerduty: {routing_key = "...", severity_mapping = {critical = "P1", ...}}. For rootly: {api_key = "...", webhook_url = "https://..."}. For opsgenie: {api_key = "...", region = "us", priority_mapping = {critical = "P1", ...}}. For incidentio: {url = "https://...", severity_mapping = {critical = "SEV0", ...}}. For webhook: {url = "https://...", method = "POST" (GET/POST/PUT/DELETE), headers = {key = "value"}, auth_type = "bearer"|"basic", api_key = "..." (for bearer), username = "...", password = "..." (for basic), custom_payload = "JSON Jinja2 template string (max 64KB)"}.
 - `name` (String) Name of the connected app.
-- `type` (String) Type of connected app (slack-webhook or pagerduty).
+- `type` (String) Type of connected app (slack-webhook, pagerduty, opsgenie, incidentio, webhook, or rootly).
 
 ### Read-Only
 

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -594,7 +594,7 @@ resource "groundcover_dataintegration" "postgresql_demo" {
     name        = "postgres demo integration"
     port        = 5432
     secure      = true
-    skipVerify  = false # set to true only for dev/test; never disable cert verification in production
+    skipVerify  = false
     version     = 1
 
     labelSettings = {

--- a/docs/resources/ingestionkey.md
+++ b/docs/resources/ingestionkey.md
@@ -44,22 +44,22 @@ variable "groundcover_backend_id" {
   description = "groundcover Backend ID"
 }
 
-# Example Ingestion Key
+# Example Ingestion Key with type "sensor"
 resource "groundcover_ingestionkey" "example" {
   name = "terraform-provider-example-ingestion-key"
-  type = "ingestion"
+  type = "sensor" # Valid values: "sensor", "rum", "thirdParty"
 
   # Optional: Enable remote configuration
   remote_config = true
 
   # Optional: Add tags
-  tags = ["terraform", "example", "ingestion"]
+  tags = ["terraform", "example", "sensor"]
 }
 
 # Example Ingestion Key with minimal configuration
 resource "groundcover_ingestionkey" "minimal" {
   name = "terraform-provider-minimal-key"
-  type = "ingestion"
+  type = "sensor"
 }
 
 output "ingestionkey_example_key" {
@@ -91,7 +91,7 @@ output "ingestionkey_minimal_key" {
 ### Required
 
 - `name` (String) The name of the ingestion key.
-- `type` (String) The type of the ingestion key (e.g., 'ingestion').
+- `type` (String) The type of the ingestion key. Valid values are: 'sensor', 'rum', 'thirdParty'.
 
 ### Optional
 

--- a/examples/resources/groundcover_ingestionkey/resource.tf
+++ b/examples/resources/groundcover_ingestionkey/resource.tf
@@ -29,22 +29,22 @@ variable "groundcover_backend_id" {
   description = "groundcover Backend ID"
 }
 
-# Example Ingestion Key
+# Example Ingestion Key with type "sensor"
 resource "groundcover_ingestionkey" "example" {
   name = "terraform-provider-example-ingestion-key"
-  type = "ingestion"
+  type = "sensor" # Valid values: "sensor", "rum", "thirdParty"
 
   # Optional: Enable remote configuration
   remote_config = true
 
   # Optional: Add tags
-  tags = ["terraform", "example", "ingestion"]
+  tags = ["terraform", "example", "sensor"]
 }
 
 # Example Ingestion Key with minimal configuration
 resource "groundcover_ingestionkey" "minimal" {
   name = "terraform-provider-minimal-key"
-  type = "ingestion"
+  type = "sensor"
 }
 
 output "ingestionkey_example_key" {
@@ -67,4 +67,4 @@ output "ingestionkey_minimal_key" {
   description = "The key value of the minimal ingestion key (sensitive)."
   value       = groundcover_ingestionkey.minimal.key
   sensitive   = true
-} 
+}

--- a/internal/provider/resource_ingestionkey.go
+++ b/internal/provider/resource_ingestionkey.go
@@ -78,7 +78,7 @@ func (r *ingestionKeyResource) Schema(_ context.Context, _ resource.SchemaReques
 				Computed:    true,
 			},
 			"type": schema.StringAttribute{
-				Description: "The type of the ingestion key (e.g., 'ingestion').",
+				Description: "The type of the ingestion key. Valid values are: 'sensor', 'rum', 'thirdParty'.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_ingestionkey_test.go
+++ b/internal/provider/resource_ingestionkey_test.go
@@ -59,6 +59,50 @@ func TestAccIngestionKeyResource(t *testing.T) {
 	})
 }
 
+func TestAccIngestionKeyResource_typeRum(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-ingestionkey-rum")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckIngestionKey(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithInCloudBackend(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIngestionKeyResourceConfigWithType(name, "rum"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_ingestionkey.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_ingestionkey.test", "type", "rum"),
+					resource.TestCheckResourceAttrSet("groundcover_ingestionkey.test", "key"),
+					resource.TestCheckResourceAttrSet("groundcover_ingestionkey.test", "created_by"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIngestionKeyResource_typeThirdParty(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-ingestionkey-tp")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckIngestionKey(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithInCloudBackend(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIngestionKeyResourceConfigWithType(name, "thirdParty"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_ingestionkey.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_ingestionkey.test", "type", "thirdParty"),
+					resource.TestCheckResourceAttrSet("groundcover_ingestionkey.test", "key"),
+					resource.TestCheckResourceAttrSet("groundcover_ingestionkey.test", "created_by"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIngestionKeyResource_disappears(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-ingestionkey")
 
@@ -81,12 +125,16 @@ func TestAccIngestionKeyResource_disappears(t *testing.T) {
 }
 
 func testAccIngestionKeyResourceConfig(name string) string {
+	return testAccIngestionKeyResourceConfigWithType(name, "sensor")
+}
+
+func testAccIngestionKeyResourceConfigWithType(name, keyType string) string {
 	return fmt.Sprintf(`
 resource "groundcover_ingestionkey" "test" {
   name = %[1]q
-  type = "sensor"
+  type = %[2]q
 }
-`, name)
+`, name, keyType)
 }
 
 func testAccCheckIngestionKeyResourceExists(n string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new connected app types: rootly, opsgenie, incidentio, and webhook with provider-specific configurations.

* **Bug Fixes**
  * Fixed documentation for ingestion key types; valid values are now correctly specified as sensor, rum, and thirdParty.

* **Tests**
  * Added acceptance tests for all ingestion key type options.

* **Documentation**
  * Updated examples and resource documentation to reflect corrected ingestion key type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->