### PR TITLE
BE-836 - Add monitor and notification routing controls to synthetic_t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+
+* Added monitor and notification routing controls to `groundcover_synthetic_test` resource — supports `monitor_name`, `severity`, `issue_summary`, `issue_description`, `no_data_state`, `execution_error_state`, `lookbehind_window`, `renotification_interval`, `enabled_workflows`, and `evaluation_interval` (interval + pending_for)
+
 ## 1.8.2
 
 * Added MS-teams connected app documentation and tests.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Basic usage examples can be found in the `examples/` directory:
 *   **Data Integration Resource:** [`examples/resources/groundcover_dataintegration/resource.tf`](./examples/resources/groundcover_dataintegration/resource.tf)
     *   Demonstrates how to create and manage data integrations.
 *   **Synthetic Test Resource:** [`examples/resources/groundcover_synthetic_test/resource.tf`](./examples/resources/groundcover_synthetic_test/resource.tf)
-    *   Demonstrates how to create and manage synthetic tests for proactive HTTP endpoint monitoring with assertions, retries, and authentication support.
+    *   Demonstrates how to create and manage synthetic tests for proactive HTTP endpoint monitoring with assertions, retries, authentication support, monitor configuration, and notification routing.
 
 ## Local Development and Testing
 

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -143,13 +143,51 @@ resource "groundcover_synthetic_test" "performance_check" {
   }
 }
 
-# Output the synthetic test IDs
+# Example: With monitor and notification routing
+resource "groundcover_synthetic_test" "monitored_check" {
+  name     = "Monitored API Check"
+  interval = "1m"
+
+  http_check {
+    url     = "https://api.example.com/health"
+    method  = "GET"
+    timeout = "10s"
+  }
+
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
+
+  monitor {
+    monitor_name            = "API Health Monitor"
+    severity                = "S1"
+    issue_summary           = "Synthetic check failed: {{ name }}"
+    issue_description       = "The synthetic test {{ name }} is failing. Check the endpoint health."
+    no_data_state           = "Alerting"
+    execution_error_state   = "Alerting"
+    renotification_interval = "1h"
+
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "0s"
+    }
+
+    enabled_workflows = ["workflow-id-1", "workflow-id-2"]
+  }
+}
+
 output "http_health_check_id" {
   value = groundcover_synthetic_test.http_health_check.id
 }
 
 output "http_post_check_id" {
   value = groundcover_synthetic_test.http_post_check.id
+}
+
+output "monitored_check_id" {
+  value = groundcover_synthetic_test.monitored_check.id
 }
 ```
 
@@ -167,6 +205,7 @@ output "http_post_check_id" {
 - `enabled` (Boolean) Whether the synthetic test is enabled. Default: `true`.
 - `http_check` (Block, Optional) HTTP check configuration. Defines the endpoint to monitor. (see [below for nested schema](#nestedblock--http_check))
 - `labels` (Map of String) Extra labels to attach to the synthetic test metrics.
+- `monitor` (Block, Optional) Monitor configuration for the synthetic test. Controls the monitor that is automatically created for this test, including alerting behavior and notification routing. (see [below for nested schema](#nestedblock--monitor))
 - `retry` (Block, Optional) Retry policy for failed checks. (see [below for nested schema](#nestedblock--retry))
 
 ### Read-Only
@@ -224,6 +263,32 @@ Optional:
 
 - `content` (String) Body content string.
 - `type` (String) Body content type: `json`, `text`, or `raw`.
+
+
+
+<a id="nestedblock--monitor"></a>
+### Nested Schema for `monitor`
+
+Optional:
+
+- `enabled_workflows` (List of String) List of workflow IDs to route notifications to. Workflows and notification policies run simultaneously.
+- `evaluation_interval` (Block, Optional) Evaluation interval settings for the monitor. (see [below for nested schema](#nestedblock--monitor--evaluation_interval))
+- `execution_error_state` (String) How the monitor behaves on execution errors. `OK` treats errors as normal, `Alerting` treats them as issues.
+- `issue_description` (String) Description template for issues created by this monitor. Supports Jinja2 templating with variables like `{{ workload }}`.
+- `issue_summary` (String) Summary template for issues created by this monitor. Supports Jinja2 templating.
+- `lookbehind_window` (String) The time window the monitor looks back for evaluation (e.g. `5m`, `10m`).
+- `monitor_name` (String) Custom name for the monitor. If not set, a default name is derived from the synthetic test name.
+- `no_data_state` (String) How the monitor behaves when there is no data. `OK` treats no data as normal, `Alerting` treats it as an issue.
+- `renotification_interval` (String) How long to wait before sending another notification while the alert is still firing (e.g. `15m`, `1h`, `4h`).
+- `severity` (String) Severity level for issues created by this monitor. Supported values: `S1`, `S2`, `S3`, `S4`, `none`.
+
+<a id="nestedblock--monitor--evaluation_interval"></a>
+### Nested Schema for `monitor.evaluation_interval`
+
+Optional:
+
+- `interval` (String) How often the monitor evaluates (e.g. `1m`, `5m`).
+- `pending_for` (String) How long all evaluations must stay true before firing (e.g. `0s`, `1m`, `5m`).
 
 
 

--- a/examples/resources/groundcover_synthetic_test/resource.tf
+++ b/examples/resources/groundcover_synthetic_test/resource.tf
@@ -128,11 +128,49 @@ resource "groundcover_synthetic_test" "performance_check" {
   }
 }
 
-# Output the synthetic test IDs
+# Example: With monitor and notification routing
+resource "groundcover_synthetic_test" "monitored_check" {
+  name     = "Monitored API Check"
+  interval = "1m"
+
+  http_check {
+    url     = "https://api.example.com/health"
+    method  = "GET"
+    timeout = "10s"
+  }
+
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
+
+  monitor {
+    monitor_name            = "API Health Monitor"
+    severity                = "S1"
+    issue_summary           = "Synthetic check failed: {{ name }}"
+    issue_description       = "The synthetic test {{ name }} is failing. Check the endpoint health."
+    no_data_state           = "Alerting"
+    execution_error_state   = "Alerting"
+    renotification_interval = "1h"
+
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "0s"
+    }
+
+    enabled_workflows = ["workflow-id-1", "workflow-id-2"]
+  }
+}
+
 output "http_health_check_id" {
   value = groundcover_synthetic_test.http_health_check.id
 }
 
 output "http_post_check_id" {
   value = groundcover_synthetic_test.http_post_check.id
+}
+
+output "monitored_check_id" {
+  value = groundcover_synthetic_test.monitored_check.id
 }

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -48,6 +48,7 @@ type syntheticTestResourceModel struct {
 	Assertion []syntheticAssertionModel `tfsdk:"assertion"`
 	Retry     *syntheticRetryModel      `tfsdk:"retry"`
 	Labels    types.Map                 `tfsdk:"labels"`
+	Monitor   *syntheticMonitorModel    `tfsdk:"monitor"`
 }
 
 type syntheticHTTPCheckModel struct {
@@ -85,6 +86,24 @@ type syntheticAssertionModel struct {
 type syntheticRetryModel struct {
 	Count    types.Int64  `tfsdk:"count"`
 	Interval types.String `tfsdk:"interval"`
+}
+
+type syntheticMonitorModel struct {
+	MonitorName            types.String                       `tfsdk:"monitor_name"`
+	Severity               types.String                       `tfsdk:"severity"`
+	IssueSummary           types.String                       `tfsdk:"issue_summary"`
+	IssueDescription       types.String                       `tfsdk:"issue_description"`
+	NoDataState            types.String                       `tfsdk:"no_data_state"`
+	ExecutionErrorState    types.String                       `tfsdk:"execution_error_state"`
+	LookbehindWindow       types.String                       `tfsdk:"lookbehind_window"`
+	RenotificationInterval types.String                       `tfsdk:"renotification_interval"`
+	EnabledWorkflows       types.List                         `tfsdk:"enabled_workflows"`
+	EvaluationInterval     *syntheticMonitorEvalIntervalModel `tfsdk:"evaluation_interval"`
+}
+
+type syntheticMonitorEvalIntervalModel struct {
+	Interval   types.String `tfsdk:"interval"`
+	PendingFor types.String `tfsdk:"pending_for"`
 }
 
 // --- Schema ---
@@ -260,6 +279,72 @@ func (r *syntheticTestResource) Schema(_ context.Context, _ resource.SchemaReque
 					"interval": schema.StringAttribute{
 						Description: "Delay between retries (e.g. `1s`, `500ms`).",
 						Optional:    true,
+					},
+				},
+			},
+			"monitor": schema.SingleNestedBlock{
+				Description: "Monitor configuration for the synthetic test. Controls the monitor that is automatically created for this test, including alerting behavior and notification routing.",
+				Attributes: map[string]schema.Attribute{
+					"monitor_name": schema.StringAttribute{
+						Description: "Custom name for the monitor. If not set, a default name is derived from the synthetic test name.",
+						Optional:    true,
+					},
+					"severity": schema.StringAttribute{
+						Description: "Severity level for issues created by this monitor. Supported values: `S1`, `S2`, `S3`, `S4`, `none`.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("S1", "S2", "S3", "S4", "none"),
+						},
+					},
+					"issue_summary": schema.StringAttribute{
+						Description: "Summary template for issues created by this monitor. Supports Jinja2 templating.",
+						Optional:    true,
+					},
+					"issue_description": schema.StringAttribute{
+						Description: "Description template for issues created by this monitor. Supports Jinja2 templating with variables like `{{ workload }}`.",
+						Optional:    true,
+					},
+					"no_data_state": schema.StringAttribute{
+						Description: "How the monitor behaves when there is no data. `OK` treats no data as normal, `Alerting` treats it as an issue.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("OK", "Alerting"),
+						},
+					},
+					"execution_error_state": schema.StringAttribute{
+						Description: "How the monitor behaves on execution errors. `OK` treats errors as normal, `Alerting` treats them as issues.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("OK", "Alerting"),
+						},
+					},
+					"lookbehind_window": schema.StringAttribute{
+						Description: "The time window the monitor looks back for evaluation (e.g. `5m`, `10m`).",
+						Optional:    true,
+					},
+					"renotification_interval": schema.StringAttribute{
+						Description: "How long to wait before sending another notification while the alert is still firing (e.g. `15m`, `1h`, `4h`).",
+						Optional:    true,
+					},
+					"enabled_workflows": schema.ListAttribute{
+						Description: "List of workflow IDs to route notifications to. Workflows and notification policies run simultaneously.",
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+				},
+				Blocks: map[string]schema.Block{
+					"evaluation_interval": schema.SingleNestedBlock{
+						Description: "Evaluation interval settings for the monitor.",
+						Attributes: map[string]schema.Attribute{
+							"interval": schema.StringAttribute{
+								Description: "How often the monitor evaluates (e.g. `1m`, `5m`).",
+								Optional:    true,
+							},
+							"pending_for": schema.StringAttribute{
+								Description: "How long all evaluations must stay true before firing (e.g. `0s`, `1m`, `5m`).",
+								Optional:    true,
+							},
+						},
 					},
 				},
 			},
@@ -549,6 +634,60 @@ func toSDKRequest(plan *syntheticTestResourceModel) *models.SyntheticTestCreateR
 	}
 
 	sdkReq.CheckConfig = checkConfig
+
+	// Monitor
+	if plan.Monitor != nil {
+		monitorConfig := &models.SyntheticMonitorConfig{}
+
+		if !plan.Monitor.MonitorName.IsNull() && !plan.Monitor.MonitorName.IsUnknown() {
+			monitorConfig.MonitorName = plan.Monitor.MonitorName.ValueString()
+		}
+		if !plan.Monitor.Severity.IsNull() && !plan.Monitor.Severity.IsUnknown() {
+			monitorConfig.Severity = plan.Monitor.Severity.ValueString()
+		}
+		if !plan.Monitor.IssueSummary.IsNull() && !plan.Monitor.IssueSummary.IsUnknown() {
+			monitorConfig.IssueSummary = plan.Monitor.IssueSummary.ValueString()
+		}
+		if !plan.Monitor.IssueDescription.IsNull() && !plan.Monitor.IssueDescription.IsUnknown() {
+			monitorConfig.IssueDescription = plan.Monitor.IssueDescription.ValueString()
+		}
+		if !plan.Monitor.NoDataState.IsNull() && !plan.Monitor.NoDataState.IsUnknown() {
+			monitorConfig.NoDataState = plan.Monitor.NoDataState.ValueString()
+		}
+		if !plan.Monitor.ExecutionErrorState.IsNull() && !plan.Monitor.ExecutionErrorState.IsUnknown() {
+			monitorConfig.ExecutionErrorState = plan.Monitor.ExecutionErrorState.ValueString()
+		}
+		if !plan.Monitor.LookbehindWindow.IsNull() && !plan.Monitor.LookbehindWindow.IsUnknown() {
+			monitorConfig.LookbehindWindow = plan.Monitor.LookbehindWindow.ValueString()
+		}
+		if !plan.Monitor.RenotificationInterval.IsNull() && !plan.Monitor.RenotificationInterval.IsUnknown() {
+			monitorConfig.RenotificationInterval = plan.Monitor.RenotificationInterval.ValueString()
+		}
+
+		if !plan.Monitor.EnabledWorkflows.IsNull() && !plan.Monitor.EnabledWorkflows.IsUnknown() {
+			workflows := make([]string, 0, len(plan.Monitor.EnabledWorkflows.Elements()))
+			for _, v := range plan.Monitor.EnabledWorkflows.Elements() {
+				if sv, ok := v.(types.String); ok {
+					workflows = append(workflows, sv.ValueString())
+				}
+			}
+			monitorConfig.EnabledWorkflows = workflows
+		}
+
+		if plan.Monitor.EvaluationInterval != nil {
+			evalInterval := &models.SyntheticMonitorEvalInterval{}
+			if !plan.Monitor.EvaluationInterval.Interval.IsNull() && !plan.Monitor.EvaluationInterval.Interval.IsUnknown() {
+				evalInterval.Interval = plan.Monitor.EvaluationInterval.Interval.ValueString()
+			}
+			if !plan.Monitor.EvaluationInterval.PendingFor.IsNull() && !plan.Monitor.EvaluationInterval.PendingFor.IsUnknown() {
+				evalInterval.PendingFor = plan.Monitor.EvaluationInterval.PendingFor.ValueString()
+			}
+			monitorConfig.EvaluationInterval = evalInterval
+		}
+
+		sdkReq.Monitor = monitorConfig
+	}
+
 	return sdkReq
 }
 
@@ -666,5 +805,84 @@ func fromSDKResponse(ctx context.Context, sdkResp *models.SyntheticTestCreateReq
 		}
 	} else {
 		state.Retry = nil
+	}
+
+	isImport := state.Monitor == nil && state.Name.IsNull()
+	if sdkResp.Monitor != nil && (state.Monitor != nil || isImport) {
+		mon := sdkResp.Monitor
+		prev := state.Monitor
+
+		monitorModel := &syntheticMonitorModel{
+			EnabledWorkflows: types.ListNull(types.StringType),
+		}
+
+		if isImport || !prev.MonitorName.IsNull() {
+			if mon.MonitorName != "" {
+				monitorModel.MonitorName = types.StringValue(mon.MonitorName)
+			}
+		}
+		if isImport || !prev.Severity.IsNull() {
+			if mon.Severity != "" {
+				monitorModel.Severity = types.StringValue(mon.Severity)
+			}
+		}
+		if isImport || !prev.IssueSummary.IsNull() {
+			if mon.IssueSummary != "" {
+				monitorModel.IssueSummary = types.StringValue(mon.IssueSummary)
+			}
+		}
+		if isImport || !prev.IssueDescription.IsNull() {
+			if mon.IssueDescription != "" {
+				monitorModel.IssueDescription = types.StringValue(mon.IssueDescription)
+			}
+		}
+		if isImport || !prev.NoDataState.IsNull() {
+			if mon.NoDataState != "" {
+				monitorModel.NoDataState = types.StringValue(mon.NoDataState)
+			}
+		}
+		if isImport || !prev.ExecutionErrorState.IsNull() {
+			if mon.ExecutionErrorState != "" {
+				monitorModel.ExecutionErrorState = types.StringValue(mon.ExecutionErrorState)
+			}
+		}
+		if isImport || !prev.LookbehindWindow.IsNull() {
+			if mon.LookbehindWindow != "" {
+				monitorModel.LookbehindWindow = types.StringValue(normalizeDuration(mon.LookbehindWindow))
+			}
+		}
+		if isImport || !prev.RenotificationInterval.IsNull() {
+			if mon.RenotificationInterval != "" {
+				monitorModel.RenotificationInterval = types.StringValue(normalizeDuration(mon.RenotificationInterval))
+			}
+		}
+
+		if len(mon.EnabledWorkflows) > 0 {
+			workflowValues := make([]string, len(mon.EnabledWorkflows))
+			copy(workflowValues, mon.EnabledWorkflows)
+			workflowsList, diags := types.ListValueFrom(ctx, types.StringType, workflowValues)
+			if !diags.HasError() {
+				monitorModel.EnabledWorkflows = workflowsList
+			}
+		}
+
+		if mon.EvaluationInterval != nil && (isImport || prev.EvaluationInterval != nil) {
+			evalModel := &syntheticMonitorEvalIntervalModel{}
+			if isImport || !prev.EvaluationInterval.Interval.IsNull() {
+				if mon.EvaluationInterval.Interval != "" {
+					evalModel.Interval = types.StringValue(normalizeDuration(mon.EvaluationInterval.Interval))
+				}
+			}
+			if isImport || !prev.EvaluationInterval.PendingFor.IsNull() {
+				if mon.EvaluationInterval.PendingFor != "" {
+					evalModel.PendingFor = types.StringValue(normalizeDuration(mon.EvaluationInterval.PendingFor))
+				}
+			}
+			monitorModel.EvaluationInterval = evalModel
+		}
+
+		state.Monitor = monitorModel
+	} else if state.Monitor != nil {
+		state.Monitor = nil
 	}
 }

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -840,12 +840,16 @@ func fromSDKResponse(ctx context.Context, sdkResp *models.SyntheticTestCreateReq
 			monitorModel.RenotificationInterval = types.StringValue(normalizeDuration(mon.RenotificationInterval))
 		}
 
-		if len(mon.EnabledWorkflows) > 0 {
-			workflowValues := make([]string, len(mon.EnabledWorkflows))
-			copy(workflowValues, mon.EnabledWorkflows)
-			workflowsList, diags := types.ListValueFrom(ctx, types.StringType, workflowValues)
-			if !diags.HasError() {
-				monitorModel.EnabledWorkflows = workflowsList
+		if !prev.EnabledWorkflows.IsNull() {
+			if len(mon.EnabledWorkflows) > 0 {
+				workflowValues := make([]string, len(mon.EnabledWorkflows))
+				copy(workflowValues, mon.EnabledWorkflows)
+				workflowsList, diags := types.ListValueFrom(ctx, types.StringType, workflowValues)
+				if !diags.HasError() {
+					monitorModel.EnabledWorkflows = workflowsList
+				}
+			} else {
+				monitorModel.EnabledWorkflows, _ = types.ListValueFrom(ctx, types.StringType, []string{})
 			}
 		}
 

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -807,8 +807,7 @@ func fromSDKResponse(ctx context.Context, sdkResp *models.SyntheticTestCreateReq
 		state.Retry = nil
 	}
 
-	isImport := state.Monitor == nil && state.Name.IsNull()
-	if sdkResp.Monitor != nil && (state.Monitor != nil || isImport) {
+	if sdkResp.Monitor != nil && state.Monitor != nil {
 		mon := sdkResp.Monitor
 		prev := state.Monitor
 
@@ -816,45 +815,29 @@ func fromSDKResponse(ctx context.Context, sdkResp *models.SyntheticTestCreateReq
 			EnabledWorkflows: types.ListNull(types.StringType),
 		}
 
-		if isImport || !prev.MonitorName.IsNull() {
-			if mon.MonitorName != "" {
-				monitorModel.MonitorName = types.StringValue(mon.MonitorName)
-			}
+		if !prev.MonitorName.IsNull() {
+			monitorModel.MonitorName = types.StringValue(mon.MonitorName)
 		}
-		if isImport || !prev.Severity.IsNull() {
-			if mon.Severity != "" {
-				monitorModel.Severity = types.StringValue(mon.Severity)
-			}
+		if !prev.Severity.IsNull() {
+			monitorModel.Severity = types.StringValue(mon.Severity)
 		}
-		if isImport || !prev.IssueSummary.IsNull() {
-			if mon.IssueSummary != "" {
-				monitorModel.IssueSummary = types.StringValue(mon.IssueSummary)
-			}
+		if !prev.IssueSummary.IsNull() {
+			monitorModel.IssueSummary = types.StringValue(mon.IssueSummary)
 		}
-		if isImport || !prev.IssueDescription.IsNull() {
-			if mon.IssueDescription != "" {
-				monitorModel.IssueDescription = types.StringValue(mon.IssueDescription)
-			}
+		if !prev.IssueDescription.IsNull() {
+			monitorModel.IssueDescription = types.StringValue(mon.IssueDescription)
 		}
-		if isImport || !prev.NoDataState.IsNull() {
-			if mon.NoDataState != "" {
-				monitorModel.NoDataState = types.StringValue(mon.NoDataState)
-			}
+		if !prev.NoDataState.IsNull() {
+			monitorModel.NoDataState = types.StringValue(mon.NoDataState)
 		}
-		if isImport || !prev.ExecutionErrorState.IsNull() {
-			if mon.ExecutionErrorState != "" {
-				monitorModel.ExecutionErrorState = types.StringValue(mon.ExecutionErrorState)
-			}
+		if !prev.ExecutionErrorState.IsNull() {
+			monitorModel.ExecutionErrorState = types.StringValue(mon.ExecutionErrorState)
 		}
-		if isImport || !prev.LookbehindWindow.IsNull() {
-			if mon.LookbehindWindow != "" {
-				monitorModel.LookbehindWindow = types.StringValue(normalizeDuration(mon.LookbehindWindow))
-			}
+		if !prev.LookbehindWindow.IsNull() {
+			monitorModel.LookbehindWindow = types.StringValue(normalizeDuration(mon.LookbehindWindow))
 		}
-		if isImport || !prev.RenotificationInterval.IsNull() {
-			if mon.RenotificationInterval != "" {
-				monitorModel.RenotificationInterval = types.StringValue(normalizeDuration(mon.RenotificationInterval))
-			}
+		if !prev.RenotificationInterval.IsNull() {
+			monitorModel.RenotificationInterval = types.StringValue(normalizeDuration(mon.RenotificationInterval))
 		}
 
 		if len(mon.EnabledWorkflows) > 0 {
@@ -866,17 +849,13 @@ func fromSDKResponse(ctx context.Context, sdkResp *models.SyntheticTestCreateReq
 			}
 		}
 
-		if mon.EvaluationInterval != nil && (isImport || prev.EvaluationInterval != nil) {
+		if mon.EvaluationInterval != nil && prev.EvaluationInterval != nil {
 			evalModel := &syntheticMonitorEvalIntervalModel{}
-			if isImport || !prev.EvaluationInterval.Interval.IsNull() {
-				if mon.EvaluationInterval.Interval != "" {
-					evalModel.Interval = types.StringValue(normalizeDuration(mon.EvaluationInterval.Interval))
-				}
+			if !prev.EvaluationInterval.Interval.IsNull() {
+				evalModel.Interval = types.StringValue(normalizeDuration(mon.EvaluationInterval.Interval))
 			}
-			if isImport || !prev.EvaluationInterval.PendingFor.IsNull() {
-				if mon.EvaluationInterval.PendingFor != "" {
-					evalModel.PendingFor = types.StringValue(normalizeDuration(mon.EvaluationInterval.PendingFor))
-				}
+			if !prev.EvaluationInterval.PendingFor.IsNull() {
+				evalModel.PendingFor = types.StringValue(normalizeDuration(mon.EvaluationInterval.PendingFor))
 			}
 			monitorModel.EvaluationInterval = evalModel
 		}

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -185,12 +185,27 @@ func TestAccSyntheticTestResource_withMonitor(t *testing.T) {
 				ResourceName:      "groundcover_synthetic_test.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"http_check.auth", "monitor.%",
-					"monitor.monitor_name", "monitor.severity", "monitor.issue_summary",
-					"monitor.issue_description", "monitor.no_data_state", "monitor.execution_error_state",
-					"monitor.lookbehind_window", "monitor.renotification_interval", "monitor.enabled_workflows",
-					"monitor.evaluation_interval.%", "monitor.evaluation_interval.interval",
-					"monitor.evaluation_interval.pending_for"},
+				// http_check.auth: sensitive fields (password/token) are never read back from the API.
+				// monitor.*: the monitor block is only tracked in state when explicitly configured;
+				// on import the prior state is empty so fromSDKResponse skips the block to avoid
+				// server-default values (issue_summary, lookbehind_window) leaking into state and
+				// causing perpetual plan diffs. Users add the monitor block to their config post-import.
+				ImportStateVerifyIgnore: []string{
+					"http_check.auth",
+					"monitor.%",
+					"monitor.monitor_name",
+					"monitor.severity",
+					"monitor.issue_summary",
+					"monitor.issue_description",
+					"monitor.no_data_state",
+					"monitor.execution_error_state",
+					"monitor.lookbehind_window",
+					"monitor.renotification_interval",
+					"monitor.enabled_workflows",
+					"monitor.evaluation_interval.%",
+					"monitor.evaluation_interval.interval",
+					"monitor.evaluation_interval.pending_for",
+				},
 			},
 			// Update monitor settings
 			{

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -308,34 +308,34 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitor(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-  name     = %[1]q
-  enabled  = true
-  interval = "1m"
+	name     = %[1]q
+	enabled  = true
+	interval = "1m"
 
-  http_check {
-    url     = "https://httpbin.org/status/200"
-    method  = "GET"
-    timeout = "10s"
-  }
+	http_check {
+		url     = "https://httpbin.org/status/200"
+		method  = "GET"
+		timeout = "10s"
+	}
 
-  assertion {
-    source   = "statusCode"
-    operator = "eq"
-    target   = "200"
-  }
+	assertion {
+		source   = "statusCode"
+		operator = "eq"
+		target   = "200"
+	}
 
-  monitor {
-    monitor_name            = "Monitor for %[1]s"
-    severity                = "S1"
-    no_data_state           = "Alerting"
-    execution_error_state   = "Alerting"
-    renotification_interval = "1h"
+	monitor {
+		monitor_name            = "Monitor for %[1]s"
+		severity                = "S1"
+		no_data_state           = "Alerting"
+		execution_error_state   = "Alerting"
+		renotification_interval = "1h"
 
-    evaluation_interval {
-      interval    = "1m"
-      pending_for = "0s"
-    }
-  }
+		evaluation_interval {
+			interval    = "1m"
+			pending_for = "0s"
+		}
+	}
 }
 `, name)
 }
@@ -343,34 +343,34 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitorUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-  name     = %[1]q
-  enabled  = true
-  interval = "1m"
+	name     = %[1]q
+	enabled  = true
+	interval = "1m"
 
-  http_check {
-    url     = "https://httpbin.org/status/200"
-    method  = "GET"
-    timeout = "10s"
-  }
+	http_check {
+		url     = "https://httpbin.org/status/200"
+		method  = "GET"
+		timeout = "10s"
+	}
 
-  assertion {
-    source   = "statusCode"
-    operator = "eq"
-    target   = "200"
-  }
+	assertion {
+		source   = "statusCode"
+		operator = "eq"
+		target   = "200"
+	}
 
-  monitor {
-    monitor_name            = "Monitor for %[1]s"
-    severity                = "S2"
-    no_data_state           = "OK"
-    execution_error_state   = "Alerting"
-    renotification_interval = "4h"
+	monitor {
+		monitor_name            = "Monitor for %[1]s"
+		severity                = "S2"
+		no_data_state           = "OK"
+		execution_error_state   = "Alerting"
+		renotification_interval = "4h"
 
-    evaluation_interval {
-      interval    = "1m"
-      pending_for = "5m"
-    }
-  }
+		evaluation_interval {
+			interval    = "1m"
+			pending_for = "5m"
+		}
+	}
 }
 `, name)
 }
@@ -378,24 +378,24 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitorMinimal(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-  name     = %[1]q
-  interval = "1m"
+	name     = %[1]q
+	interval = "1m"
 
-  http_check {
-    url     = "https://httpbin.org/status/200"
-    method  = "GET"
-    timeout = "10s"
-  }
+	http_check {
+		url     = "https://httpbin.org/status/200"
+		method  = "GET"
+		timeout = "10s"
+	}
 
-  assertion {
-    source   = "statusCode"
-    operator = "eq"
-    target   = "200"
-  }
+	assertion {
+		source   = "statusCode"
+		operator = "eq"
+		target   = "200"
+	}
 
-  monitor {
-    severity = "S2"
-  }
+	monitor {
+		severity = "S2"
+	}
 }
 `, name)
 }

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -158,6 +158,75 @@ func TestAccSyntheticTestResource_disappears(t *testing.T) {
 	})
 }
 
+func TestAccSyntheticTestResource_withMonitor(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-monitor")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with monitor block
+			{
+				Config: testAccSyntheticTestResourceConfig_withMonitor(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.monitor_name", "Monitor for "+name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.severity", "S1"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.no_data_state", "Alerting"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.execution_error_state", "Alerting"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.renotification_interval", "1h"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.evaluation_interval.interval", "1m"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.evaluation_interval.pending_for", "0s"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "groundcover_synthetic_test.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"http_check.auth", "monitor.%",
+					"monitor.monitor_name", "monitor.severity", "monitor.issue_summary",
+					"monitor.issue_description", "monitor.no_data_state", "monitor.execution_error_state",
+					"monitor.lookbehind_window", "monitor.renotification_interval", "monitor.enabled_workflows",
+					"monitor.evaluation_interval.%", "monitor.evaluation_interval.interval",
+					"monitor.evaluation_interval.pending_for"},
+			},
+			// Update monitor settings
+			{
+				Config: testAccSyntheticTestResourceConfig_withMonitorUpdated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.severity", "S2"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.no_data_state", "OK"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.renotification_interval", "4h"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.evaluation_interval.pending_for", "5m"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccSyntheticTestResource_withMonitorMinimal(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-mon-min")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with minimal monitor (just severity)
+			{
+				Config: testAccSyntheticTestResourceConfig_withMonitorMinimal(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "monitor.severity", "S2"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccSyntheticTestResourceConfig_basic(name string) string {
@@ -231,6 +300,101 @@ resource "groundcover_synthetic_test" "test" {
   retry {
     count    = 3
     interval = "500ms"
+  }
+}
+`, name)
+}
+
+func testAccSyntheticTestResourceConfig_withMonitor(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
+
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
+
+  monitor {
+    monitor_name            = "Monitor for %[1]s"
+    severity                = "S1"
+    no_data_state           = "Alerting"
+    execution_error_state   = "Alerting"
+    renotification_interval = "1h"
+
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "0s"
+    }
+  }
+}
+`, name)
+}
+
+func testAccSyntheticTestResourceConfig_withMonitorUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
+
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
+
+  monitor {
+    monitor_name            = "Monitor for %[1]s"
+    severity                = "S2"
+    no_data_state           = "OK"
+    execution_error_state   = "Alerting"
+    renotification_interval = "4h"
+
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "5m"
+    }
+  }
+}
+`, name)
+}
+
+func testAccSyntheticTestResourceConfig_withMonitorMinimal(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  interval = "1m"
+
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
+
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
+
+  monitor {
+    severity = "S2"
   }
 }
 `, name)

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -308,34 +308,34 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitor(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-	name     = %[1]q
-	enabled  = true
-	interval = "1m"
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
 
-	http_check {
-		url     = "https://httpbin.org/status/200"
-		method  = "GET"
-		timeout = "10s"
-	}
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
 
-	assertion {
-		source   = "statusCode"
-		operator = "eq"
-		target   = "200"
-	}
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
 
-	monitor {
-		monitor_name            = "Monitor for %[1]s"
-		severity                = "S1"
-		no_data_state           = "Alerting"
-		execution_error_state   = "Alerting"
-		renotification_interval = "1h"
+  monitor {
+    monitor_name            = "Monitor for %[1]s"
+    severity                = "S1"
+    no_data_state           = "Alerting"
+    execution_error_state   = "Alerting"
+    renotification_interval = "1h"
 
-		evaluation_interval {
-			interval    = "1m"
-			pending_for = "0s"
-		}
-	}
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "0s"
+    }
+  }
 }
 `, name)
 }
@@ -343,34 +343,34 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitorUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-	name     = %[1]q
-	enabled  = true
-	interval = "1m"
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
 
-	http_check {
-		url     = "https://httpbin.org/status/200"
-		method  = "GET"
-		timeout = "10s"
-	}
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
 
-	assertion {
-		source   = "statusCode"
-		operator = "eq"
-		target   = "200"
-	}
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
 
-	monitor {
-		monitor_name            = "Monitor for %[1]s"
-		severity                = "S2"
-		no_data_state           = "OK"
-		execution_error_state   = "Alerting"
-		renotification_interval = "4h"
+  monitor {
+    monitor_name            = "Monitor for %[1]s"
+    severity                = "S2"
+    no_data_state           = "OK"
+    execution_error_state   = "Alerting"
+    renotification_interval = "4h"
 
-		evaluation_interval {
-			interval    = "1m"
-			pending_for = "5m"
-		}
-	}
+    evaluation_interval {
+      interval    = "1m"
+      pending_for = "5m"
+    }
+  }
 }
 `, name)
 }
@@ -378,24 +378,24 @@ resource "groundcover_synthetic_test" "test" {
 func testAccSyntheticTestResourceConfig_withMonitorMinimal(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {
-	name     = %[1]q
-	interval = "1m"
+  name     = %[1]q
+  interval = "1m"
 
-	http_check {
-		url     = "https://httpbin.org/status/200"
-		method  = "GET"
-		timeout = "10s"
-	}
+  http_check {
+    url     = "https://httpbin.org/status/200"
+    method  = "GET"
+    timeout = "10s"
+  }
 
-	assertion {
-		source   = "statusCode"
-		operator = "eq"
-		target   = "200"
-	}
+  assertion {
+    source   = "statusCode"
+    operator = "eq"
+    target   = "200"
+  }
 
-	monitor {
-		severity = "S2"
-	}
+  monitor {
+    severity = "S2"
+  }
 }
 `, name)
 }


### PR DESCRIPTION
…est resource

## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional monitor configuration for synthetic tests (monitor name, severity, issue metadata, alert/no-data/execution states, renotification, evaluation intervals, enabled workflows) and a monitored_check_id output.

* **Documentation**
  * Updated resource docs and examples to show the monitored synthetic test example, nested evaluation_interval fields, and the monitored_check_id output.

* **Tests**
  * Added acceptance tests for full and minimal monitor configurations, import, update, and validation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->