### PR TITLE
Fix dashboard update CurrentRevision excluded_if validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.9.1
 
 * Fixed dashboard update failing with `CurrentRevision excluded_if` validation error — use `Override: true` instead of sending `CurrentRevision` in update requests
+* Deprecated the `override` attribute on `groundcover_dashboard` — it is now always enabled internally and the attribute will be removed in a future version
+* Added `TestAccDashboardResource_Update` acceptance test covering name, description, and preset (spec) updates
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+* Fixed dashboard update failing with `CurrentRevision excluded_if` validation error — use `Override: true` instead of sending `CurrentRevision` in update requests
+
 ## 1.9.0
 
 * Added import documentation for all resources so `terraform import` usage is documented in the registry

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -202,7 +202,7 @@ output "simple_dashboard_owner" {
 ### Optional
 
 - `description` (String) The description of the dashboard.
-- `override` (Boolean) Whether to override the dashboard on update.
+- `override` (Boolean, Deprecated) Deprecated: this attribute is ignored. Override is always enabled for terraform-managed updates.
 - `team` (String) The team that owns the dashboard.
 
 ### Read-Only

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -360,13 +360,11 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		"state_preset_len":  len(state.Preset.ValueString()),
 	})
 
-	// First, read the current state from the API to get the latest revision number
-	// This prevents concurrency conflicts when the resource was modified externally
-	// and ensures we use the most up-to-date revision number
-	tflog.Debug(ctx, "Update: Reading current dashboard state before update to get latest revision", map[string]interface{}{
+	// Verify the dashboard still exists before updating
+	tflog.Debug(ctx, "Update: Verifying dashboard exists before update", map[string]interface{}{
 		"uuid": state.UUID.ValueString(),
 	})
-	apiCurrentState, err := r.client.GetDashboard(ctx, state.UUID.ValueString())
+	_, err := r.client.GetDashboard(ctx, state.UUID.ValueString())
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			resp.Diagnostics.AddError(
@@ -382,56 +380,29 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	// Log API current state for comparison
-	tflog.Debug(ctx, "Update: API current state before update", map[string]interface{}{
-		"uuid":            state.UUID.ValueString(),
-		"api_name":        apiCurrentState.Name,
-		"api_description": apiCurrentState.Description,
-		"api_team":        apiCurrentState.Team,
-		"api_revision":    apiCurrentState.RevisionNumber,
-		"api_preset_len":  len(apiCurrentState.Preset),
-		"api_owner":       apiCurrentState.Owner,
-		"api_status":      apiCurrentState.Status,
-	})
-
-	// Use the current revision number from the API for the update request
-	currentRevision := apiCurrentState.RevisionNumber
-	tflog.Debug(ctx, "Update: Using current revision from API for update", map[string]interface{}{
-		"uuid":             state.UUID.ValueString(),
-		"state_revision":   state.RevisionNumber.ValueInt32(),
-		"api_revision":     currentRevision,
-		"revision_changed": state.RevisionNumber.ValueInt32() != int32(currentRevision),
-	})
-
 	// Build update request - always use plan values for all fields
-	// The API requires all fields to be present in the update request
+	// Use Override: true since Terraform is the source of truth.
+	// Don't send CurrentRevision — the API rejects it with excluded_if when Override is true.
 	updateReq := &models.UpdateDashboardRequest{
-		Name:            plan.Name.ValueString(),
-		Description:     plan.Description.ValueString(),
-		Team:            plan.Team.ValueString(),
-		Preset:          plan.Preset.ValueString(),
-		IsProvisioned:   true, // Always set to true as requested
-		CurrentRevision: currentRevision,
-		Override:        false, // Use false by default to avoid conflicts
+		Name:          plan.Name.ValueString(),
+		Description:   plan.Description.ValueString(),
+		Team:          plan.Team.ValueString(),
+		Preset:        plan.Preset.ValueString(),
+		IsProvisioned: true,
+		Override:      true,
 	}
 
 	// Log what we're sending in the update request
 	tflog.Debug(ctx, "Update: Sending update request", map[string]interface{}{
-		"uuid":                     state.UUID.ValueString(),
-		"request_name":             updateReq.Name,
-		"request_description":      updateReq.Description,
-		"request_team":             updateReq.Team,
-		"request_preset_len":       len(updateReq.Preset),
-		"request_is_provisioned":   updateReq.IsProvisioned,
-		"request_current_revision": updateReq.CurrentRevision,
-		"request_override":         updateReq.Override,
-		"request_preset_preview":   getPreview(updateReq.Preset, 200),
+		"uuid":                   state.UUID.ValueString(),
+		"request_name":           updateReq.Name,
+		"request_description":    updateReq.Description,
+		"request_team":           updateReq.Team,
+		"request_preset_len":     len(updateReq.Preset),
+		"request_is_provisioned": updateReq.IsProvisioned,
+		"request_override":       updateReq.Override,
+		"request_preset_preview": getPreview(updateReq.Preset, 200),
 	})
-
-	// Only set override to true if explicitly set in the plan
-	if !plan.Override.IsNull() && !plan.Override.IsUnknown() && plan.Override.ValueBool() {
-		updateReq.Override = true
-	}
 
 	dashboard, err := r.client.UpdateDashboard(ctx, state.UUID.ValueString(), updateReq)
 	if err != nil {
@@ -462,9 +433,7 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		"description_match":    updateReq.Description == dashboard.Description,
 		"team_match":           updateReq.Team == dashboard.Team,
 		"preset_string_match":  updateReq.Preset == dashboard.Preset,
-		"revision_incremented": dashboard.RevisionNumber > currentRevision,
-		"revision_before":      currentRevision,
-		"revision_after":       dashboard.RevisionNumber,
+		"revision_after": dashboard.RevisionNumber,
 	})
 
 	plan.UUID = types.StringValue(dashboard.UUID)
@@ -492,8 +461,7 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		"plan_eq_state":    planPresetStr == statePresetStr,
 		"plan_eq_api":      planPresetStr == apiPresetStr,
 		"state_eq_api":     statePresetStr == apiPresetStr,
-		"revision_before":  currentRevision,
-		"revision_after":   dashboard.RevisionNumber,
+		"revision_after": dashboard.RevisionNumber,
 	})
 
 	// Normalize all three presets for detailed comparison

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -37,6 +37,7 @@ type dashboardResourceModel struct {
 	Team           types.String `tfsdk:"team"`
 	Preset         types.String `tfsdk:"preset"`
 	RevisionNumber types.Int32  `tfsdk:"revision_number"`
+	Override       types.Bool   `tfsdk:"override"`
 	Owner          types.String `tfsdk:"owner"`
 	Status         types.String `tfsdk:"status"`
 }
@@ -75,6 +76,11 @@ func (r *dashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"revision_number": schema.Int32Attribute{
 				Description: "The revision number of the dashboard.",
 				Computed:    true,
+			},
+			"override": schema.BoolAttribute{
+				Description:        "Deprecated: this attribute is ignored. Override is always enabled for terraform-managed updates.",
+				Optional:           true,
+				DeprecationMessage: "This attribute is ignored and will be removed in a future version. Override is always enabled for terraform-managed updates.",
 			},
 			"owner": schema.StringAttribute{
 				Description: "The owner of the dashboard.",

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -428,12 +428,12 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 
 	// Log field-by-field comparison: request vs response
 	tflog.Debug(ctx, "Update: Request vs Response comparison", map[string]interface{}{
-		"uuid":                 state.UUID.ValueString(),
-		"name_match":           updateReq.Name == dashboard.Name,
-		"description_match":    updateReq.Description == dashboard.Description,
-		"team_match":           updateReq.Team == dashboard.Team,
-		"preset_string_match":  updateReq.Preset == dashboard.Preset,
-		"revision_after": dashboard.RevisionNumber,
+		"uuid":                state.UUID.ValueString(),
+		"name_match":          updateReq.Name == dashboard.Name,
+		"description_match":   updateReq.Description == dashboard.Description,
+		"team_match":          updateReq.Team == dashboard.Team,
+		"preset_string_match": updateReq.Preset == dashboard.Preset,
+		"revision_after":      dashboard.RevisionNumber,
 	})
 
 	plan.UUID = types.StringValue(dashboard.UUID)
@@ -461,7 +461,7 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 		"plan_eq_state":    planPresetStr == statePresetStr,
 		"plan_eq_api":      planPresetStr == apiPresetStr,
 		"state_eq_api":     statePresetStr == apiPresetStr,
-		"revision_after": dashboard.RevisionNumber,
+		"revision_after":   dashboard.RevisionNumber,
 	})
 
 	// Normalize all three presets for detailed comparison

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -37,7 +37,6 @@ type dashboardResourceModel struct {
 	Team           types.String `tfsdk:"team"`
 	Preset         types.String `tfsdk:"preset"`
 	RevisionNumber types.Int32  `tfsdk:"revision_number"`
-	Override       types.Bool   `tfsdk:"override"`
 	Owner          types.String `tfsdk:"owner"`
 	Status         types.String `tfsdk:"status"`
 }
@@ -76,10 +75,6 @@ func (r *dashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"revision_number": schema.Int32Attribute{
 				Description: "The revision number of the dashboard.",
 				Computed:    true,
-			},
-			"override": schema.BoolAttribute{
-				Description: "Whether to override the dashboard on update.",
-				Optional:    true,
 			},
 			"owner": schema.StringAttribute{
 				Description: "The owner of the dashboard.",

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -60,6 +60,7 @@ func TestAccDashboardResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"override",
 					"preset",
 				},
 			},

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -60,7 +60,6 @@ func TestAccDashboardResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"override",
 					"preset",
 				},
 			},
@@ -71,6 +70,48 @@ func TestAccDashboardResource(t *testing.T) {
 					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", "Updated dashboard description"),
 					resource.TestCheckResourceAttr("groundcover_dashboard.test", "team", "engineering"),
 					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "preset"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDashboardResource_Update(t *testing.T) {
+	timestamp := time.Now().Unix()
+	dashboardName := fmt.Sprintf("update_dashboard_%d", timestamp)
+	updatedName := fmt.Sprintf("updated_dashboard_%d", timestamp)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccDashboardResourceConfigSimple(dashboardName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "name", dashboardName),
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", "Simple test dashboard"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "id"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "revision_number"),
+				),
+			},
+			// Update name and description
+			{
+				Config: testAccDashboardResourceConfigUpdatedNameAndDescription(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "name", updatedName),
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", "Updated description"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "id"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "revision_number"),
+				),
+			},
+			// Update preset (spec change)
+			{
+				Config: testAccDashboardResourceConfigUpdatedPreset(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "name", updatedName),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "preset"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "revision_number"),
 				),
 			},
 		},
@@ -340,6 +381,65 @@ resource "groundcover_dashboard" "test" {
     duration      = "Last 1 hour"
     widgets       = []
     layout        = []
+    variables     = {}
+    schemaVersion = 3
+  })
+}
+`, name)
+}
+
+func testAccDashboardResourceConfigUpdatedNameAndDescription(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_dashboard" "test" {
+  name        = "%s"
+  description = "Updated description"
+  preset      = jsonencode({
+    duration      = "Last 1 hour"
+    widgets       = []
+    layout        = []
+    variables     = {}
+    schemaVersion = 3
+  })
+}
+`, name)
+}
+
+func testAccDashboardResourceConfigUpdatedPreset(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_dashboard" "test" {
+  name        = "%s"
+  description = "Updated description"
+  preset      = jsonencode({
+    duration = "Last 6 hours"
+    layout = [
+      {
+        id   = "A"
+        x    = 0
+        y    = 0
+        w    = 12
+        h    = 6
+        minH = 2
+      }
+    ]
+    widgets = [
+      {
+        id   = "A"
+        type = "widget"
+        name = "Updated Widget"
+        queries = [
+          {
+            id         = "A"
+            expr       = "avg(groundcover_node_rt_disk_space_used_percent{})"
+            dataType   = "metrics"
+            step       = null
+            editorMode = "builder"
+          }
+        ]
+        visualizationConfig = {
+          type = "time-series"
+        }
+      }
+    ]
     variables     = {}
     schemaVersion = 3
   })


### PR DESCRIPTION
## Summary
- Use `Override: true` and omit `CurrentRevision` from the dashboard update request body
- Terraform is the source of truth, so revision-based concurrency control is unnecessary
- The API rejects `CurrentRevision` when `Override` is set due to an `excluded_if` validation rule
- Remove the `override` schema attribute — it's now always true internally, so exposing it to users is misleading
- Add `TestAccDashboardResource_Update` covering name, description, and preset (spec) changes

Closes INF-1011

## Checklist
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality (N/A — bug fix, no new functionality)
- [ ] I have updated the README.md with details of changes (N/A — bug fix, no user-facing config changes)
- [x] I have updated the CHANGELOG.md file

## Test plan
- [x] `go build ./...` passes
- [x] All 6 dashboard acceptance tests pass
- [x] `TestAccDashboardResource_Update` covers name, description, and preset updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard update failures by always using an override update path and avoiding sent revision data, improving reliability of dashboard saves.

* **Chores**
  * Reduced verbose debug output during dashboard updates by removing detailed pre-update revision and concurrency logs.

* **Tests**
  * Added acceptance tests covering multi-step dashboard updates to validate name/description/preset changes and stable IDs.

* **Documentation**
  * Marked the dashboard override argument as deprecated and documented that it is ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->