### PR TITLE
INF-1067 - Fix handleApiError resource not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.2
+
+* Fixed `handleApiError` incorrectly mapping non-404 API errors to "resource not found" when the error message contained the substring "not found" — the status code regex now handles go-swagger's `[STATUS_CODE]` error format, and substring-based fallbacks are only used when no HTTP status code can be extracted
+* Same fix applied to the "read-only" error mapping to prevent similar false positives
+
 ## 1.9.1
 
 * Fixed dashboard update failing with `CurrentRevision excluded_if` validation error — use `Override: true` instead of sending `CurrentRevision` in update requests

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -354,7 +354,8 @@ func NewSdkClientWrapper(ctx context.Context, baseURLStr, apiKey, backendID stri
 }
 
 // statusCodeRegex extracts the HTTP status code from SDK error strings.
-var statusCodeRegex = regexp.MustCompile(`status code (\d+)`)
+// Matches both "status code 400" and go-swagger's "[METHOD PATH][400]" format.
+var statusCodeRegex = regexp.MustCompile(`(?:status code (\d+)|\]\[(\d{3})\] )`)
 
 // handleApiError maps SDK error strings to standard provider errors (ErrNotFound, etc.)
 // or returns a wrapped generic error if no specific mapping applies.
@@ -377,7 +378,11 @@ func handleApiError(ctx context.Context, err error, operation string, resourceId
 
 	match := statusCodeRegex.FindStringSubmatch(errStr)
 	if len(match) > 1 {
-		extractedCode, parseErr := strconv.Atoi(match[1])
+		codeStr := match[1]
+		if codeStr == "" {
+			codeStr = match[2]
+		}
+		extractedCode, parseErr := strconv.Atoi(codeStr)
 		if parseErr == nil {
 			statusCode = extractedCode
 			logFields["extracted_status_code_regex"] = statusCode
@@ -419,7 +424,7 @@ func handleApiError(ctx context.Context, err error, operation string, resourceId
 		tflog.Warn(ctx, "Mapping SDK error to ErrNotFound based on 404 status code.", logFields)
 		return ErrNotFound
 	}
-	if strings.Contains(lowerErrStr, "not found") || strings.Contains(errStr, " 404 ") || strings.Contains(errStr, "[404]") {
+	if statusCode == -1 && (strings.Contains(lowerErrStr, "not found") || strings.Contains(errStr, " 404 ") || strings.Contains(errStr, "[404]")) {
 		tflog.Warn(ctx, "Mapping SDK error to ErrNotFound based on substring match ('not found', ' 404 ', or '[404]').", logFields)
 		return ErrNotFound
 	}
@@ -448,7 +453,7 @@ func handleApiError(ctx context.Context, err error, operation string, resourceId
 		return ErrNotFound
 	}
 
-	if strings.Contains(lowerErrStr, "read-only") || strings.Contains(lowerErrStr, "read only") {
+	if statusCode == -1 && (strings.Contains(lowerErrStr, "read-only") || strings.Contains(lowerErrStr, "read only")) {
 		tflog.Warn(ctx, "Mapping SDK error to ErrReadOnly based on substring match.", logFields)
 		return ErrReadOnly
 	}

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -17,28 +17,80 @@ func TestHandleApiError(t *testing.T) {
 	tests := []struct {
 		name        string
 		err         error
+		operation   string
 		expectedErr error
+		checkIs     error
 	}{
 		{
 			name:        "nil error",
 			err:         nil,
+			operation:   "test-operation",
 			expectedErr: nil,
 		},
 		{
 			name:        "generic error",
 			err:         errors.New("generic error"),
+			operation:   "test-operation",
 			expectedErr: errors.New("generic error"),
+		},
+		{
+			name:        "go-swagger 404 maps to ErrNotFound",
+			err:         errors.New(`[GET /api/connected-apps/v1/abc][404] getConnectedAppNotFound`),
+			operation:   "GetConnectedApp",
+			expectedErr: ErrNotFound,
+			checkIs:     ErrNotFound,
+		},
+		{
+			name:        "go-swagger 400 with not found in message should NOT map to ErrNotFound",
+			err:         errors.New(`[POST /api/connected-apps/v1][400] createConnectedAppBadRequest {"message":"invalid custom payload template: Tag '22id' not found (or beginning tag not provided)"}`),
+			operation:   "CreateConnectedApp",
+			expectedErr: errors.New("CreateConnectedApp failed"),
+			checkIs:     nil,
+		},
+		{
+			name:        "go-swagger 400 should surface real error message",
+			err:         errors.New(`[POST /api/monitors/v1][400] createMonitorBadRequest {"message":"invalid monitor configuration: field 'query' is required"}`),
+			operation:   "CreateMonitor",
+			expectedErr: errors.New("CreateMonitor failed"),
+			checkIs:     nil,
+		},
+		{
+			name:        "go-swagger 500 with not found in message should NOT map to ErrNotFound",
+			err:         errors.New(`[PUT /api/dashboards/v1/abc][500] updateDashboardInternalServerError {"message":"widget not found in layout"}`),
+			operation:   "UpdateDashboard",
+			expectedErr: errors.New("UpdateDashboard failed"),
+			checkIs:     nil,
+		},
+		{
+			name:        "status code format maps correctly",
+			err:         errors.New("request failed with status code 404"),
+			operation:   "GetMonitor",
+			expectedErr: ErrNotFound,
+			checkIs:     ErrNotFound,
+		},
+		{
+			name:        "fallback not found substring works when no status code extractable",
+			err:         errors.New("resource not found"),
+			operation:   "GetMonitor",
+			expectedErr: ErrNotFound,
+			checkIs:     ErrNotFound,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := handleApiError(ctx, tt.err, "test-operation", "test-resource")
+			result := handleApiError(ctx, tt.err, tt.operation, "test-resource")
 
 			if tt.expectedErr == nil {
 				assert.Nil(t, result)
 			} else {
-				assert.Error(t, result)
+				require.Error(t, result)
+				if tt.checkIs != nil {
+					assert.ErrorIs(t, result, tt.checkIs, "expected error to wrap %v, got: %v", tt.checkIs, result)
+				} else {
+					assert.NotErrorIs(t, result, ErrNotFound, "error should NOT be mapped to ErrNotFound: %v", result)
+					assert.Contains(t, result.Error(), tt.operation+" failed")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
* Fixed `handleApiError` incorrectly mapping non-404 API errors to "resource not found" when the error message contained the substring "not found" — the status code regex now handles go-swagger's `[STATUS_CODE]` error format, and substring-based fallbacks are only used when no HTTP status code can be extracted
* Same fix applied to the "read-only" error mapping to prevent similar false positives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API error handling to accurately report error types instead of incorrectly mapping errors to "resource not found" based solely on message content when HTTP status codes are available.
  * Improved error classification for both standard and read-only API errors to provide more precise error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->