### PR TITLE
INF-1157: Pin GoReleaser to v2.14.3 to fix Terraform Registry sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
+          # Pin to v2.14.3 to work around https://github.com/goreleaser/goreleaser/issues/6514
+          # GoReleaser v2.15.x adds SHA256SUMS.sig to the checksums file, which breaks
+          # Terraform Registry validation. Remove this pin once a patched version is released.
+          version: "v2.14.3"
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.


### PR DESCRIPTION
## Summary

- Pin GoReleaser to `v2.14.3` in the release workflow to work around a [bug in v2.15.x](https://github.com/goreleaser/goreleaser/issues/6514) that adds `SHA256SUMS.sig` to the checksums file, causing Terraform Registry validation to reject releases
- This is a temporary pin — remove once GoReleaser ships a fix

## Context

The `v1.10.0` release was not picked up by the Terraform Registry because the `SHA256SUMS` file contained an entry for `SHA256SUMS.sig`, which is not a valid platform asset or manifest. The registry silently rejects releases that fail this validation.

Linear: https://linear.app/groundcover/issue/INF-1157

## Next steps after merge

1. Delete the current `v1.10.0` release and tag
2. Re-tag and re-release `v1.10.0`
3. Verify `SHA256SUMS` no longer contains the `.sig` entry
4. Confirm the version appears on the Terraform Registry

## Checklist

- [x] I have written acceptance tests for my changes — N/A (CI config only)
- [x] I have run `make generate` to update generated docs — N/A
- [x] I have added examples demonstrating the new functionality — N/A
- [x] I have updated the README.md with details of changes — N/A
- [x] I have updated the CHANGELOG.md file — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process stability by pinning the GoReleaser tool version for consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->