### PR TITLE
bertin/inf-1454-tf-provider-release-workflow-test-timeout-60m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           GROUNDCOVER_API_URL: ${{ secrets.GROUNDCOVER_API_URL }}
           GROUNDCOVER_BACKEND_ID: ${{ secrets.GROUNDCOVER_BACKEND_ID }}
           GROUNDCOVER_INCLOUD_BACKEND_ID: ${{ secrets.GROUNDCOVER_INCLOUD_BACKEND_ID }}
-        run: go test ./internal/provider -v -timeout 30m
+        run: go test ./internal/provider -v -timeout 60m
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         id: import_gpg


### PR DESCRIPTION
# User description
## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] I have written acceptance tests for my changes
- [ ] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [ ] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend the release workflow's provider test step to increase the <code>go test</code> timeout to 60 minutes so tf provider releases can finish within the GitHub Actions limit. Preserve the existing import and environment steps so the workflow continues to gather secrets and sign artifacts.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>INF-1157: Pin GoReleas...</td><td>March 31, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>revert to new secret name</td><td>August 05, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/85?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD testing configuration to allow extended test execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->