### PR TITLE
BE-1379: update synthetics ssl/tcp tests to use source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.12.2
+
+* Updated `groundcover_synthetic_test` assertion `source` field — SSL/TLS properties (`certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`) and TCP properties (`tcpConnection`, `responseContains`) can now be used directly as `source` values instead of requiring `source = "ssl"/"tcp"` with a separate `property` field
+* Added config validation that rejects `property` when using a property-as-source value (e.g., `source = "certificateValid"` with `property` set)
+* Updated docs and examples to use the new direct-source syntax; the old `source + property` syntax remains fully backwards compatible
+
 ## 1.12.1
 
 * Fixed DNS assertion source — fixed from `dns` to `dnsAnswer` to match the backend API

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -624,7 +624,7 @@ assertion {
 Required:
 
 - `operator` (String) Comparison operator: `eq`, `ne`, `gt`, `lt`, `contains`, `exists`, `notExists`, `startsWith`, `endsWith`, `regex`, `oneOf`.
-- `source` (String) What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. SSL/TLS: `ssl` (basic check), or directly: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. TCP: `tcp` (connection check), or directly: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.
+- `source` (String) What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. SSL/TLS: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. TCP: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.
 
 Optional:
 

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -624,7 +624,7 @@ assertion {
 Required:
 
 - `operator` (String) Comparison operator: `eq`, `ne`, `gt`, `lt`, `contains`, `exists`, `notExists`, `startsWith`, `endsWith`, `regex`, `oneOf`.
-- `source` (String) What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. SSL/TLS: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. TCP: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.
+- `source` (String) What to assert on. All check types: `responseTime`. HTTP: `statusCode`, `responseHeader`, `jsonBody`, `responseBody`. SSL/TLS: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. TCP: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.
 
 Optional:
 

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -379,9 +379,9 @@ output "dns_check_id" {
 
 ## Assertion Source Reference
 
-Each assertion `source` determines what aspect of the check result to evaluate. The table below summarizes which sources are available for each check type, followed by detailed usage for each source.
+Each assertion `source` determines what aspect of the check result to evaluate. The sections below describe which sources are available for each check type, along with detailed usage for each source.
 
-~> **Note:** Starting from version BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
+~> **Note:** Starting from BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
 
 ### `statusCode`
 

--- a/docs/resources/synthetic_test.md
+++ b/docs/resources/synthetic_test.md
@@ -236,16 +236,14 @@ resource "groundcover_synthetic_test" "ssl_check" {
 
   # Check that the certificate is valid
   assertion {
-    source   = "ssl"
-    property = "certificateValid"
+    source   = "certificateValid"
     operator = "eq"
     target   = "true"
   }
 
   # Check that the certificate expires in more than 30 days
   assertion {
-    source   = "ssl"
-    property = "certificateExpiresIn"
+    source   = "certificateExpiresIn"
     operator = "gt"
     target   = "30"
   }
@@ -266,15 +264,13 @@ resource "groundcover_synthetic_test" "ssl_tls_check" {
   }
 
   assertion {
-    source   = "ssl"
-    property = "certificateValid"
+    source   = "certificateValid"
     operator = "eq"
     target   = "true"
   }
 
   assertion {
-    source   = "ssl"
-    property = "chainValid"
+    source   = "chainValid"
     operator = "eq"
     target   = "true"
   }
@@ -291,7 +287,7 @@ resource "groundcover_synthetic_test" "tcp_check" {
   }
 
   assertion {
-    source   = "tcp"
+    source   = "tcpConnection"
     operator = "exists"
     target   = "true"
   }
@@ -312,7 +308,7 @@ resource "groundcover_synthetic_test" "tcp_send_check" {
   }
 
   assertion {
-    source   = "tcp"
+    source   = "tcpConnection"
     operator = "exists"
     target   = "true"
   }
@@ -381,11 +377,47 @@ output "dns_check_id" {
 }
 ```
 
-## Assertion Property Reference
+## Assertion Source Reference
 
-The `property` field in an assertion specifies which property to evaluate within the assertion source. Its usage varies by source:
+Each assertion `source` determines what aspect of the check result to evaluate. The table below summarizes which sources are available for each check type, followed by detailed usage for each source.
+
+~> **Note:** Starting from version BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
+
+### `statusCode`
+
+Applies to: `http_check`
+
+Asserts on the HTTP response status code. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `ne`, `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "statusCode"
+  operator = "eq"
+  target   = "200"
+}
+```
+
+### `responseTime`
+
+Applies to: `http_check`, `ssl_check`, `tcp_check`, `dns_check`
+
+Asserts on the total response time in milliseconds. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "responseTime"
+  operator = "lt"
+  target   = "5000"
+}
+```
 
 ### `responseHeader`
+
+Applies to: `http_check`
 
 Set `property` to the header name (case-insensitive).
 
@@ -402,6 +434,8 @@ assertion {
 
 ### `jsonBody`
 
+Applies to: `http_check`
+
 Set `property` to a dot-notation path into the JSON response body (e.g. `user.name`, `data.items`).
 
 Supported operators: `exists`, `notExists`, `eq`, `ne`, `contains`.
@@ -417,6 +451,8 @@ assertion {
 
 ### `responseBody`
 
+Applies to: `http_check`
+
 Asserts against the entire raw response body as plain text. The `property` field is not used for this source and should be omitted.
 
 Supported operators: `eq`, `ne`, `contains`, `exists`, `notExists`.
@@ -429,31 +465,129 @@ assertion {
 }
 ```
 
-### `ssl`
+### `certificateValid`
 
-Set `property` to one of the following:
+Applies to: `ssl_check`
 
-| Property | Description | Operators | Target example |
-|---|---|---|---|
-| `certificateValid` | Whether the certificate is valid | `eq` | `true` / `false` |
-| `certificateExpiresIn` | Days until certificate expiry | `gt`, `lt` | `30` |
-| `tlsVersion` | Negotiated TLS version | `eq`, `gt`, `lt` | `1.2` |
-| `chainValid` | Whether the certificate chain is valid | `eq` | `true` / `false` |
-| `cipherSuite` | Negotiated cipher suite | `eq`, `contains` | `AES256` |
+Asserts whether the SSL certificate is valid. The `property` field is not used for this source and should be omitted.
 
-### `tcp`
-
-The `property` field is optional for TCP assertions. When omitted, operators act as connection checks by default.
-
-| Property | Description | Operators |
-|---|---|---|
-| `connection` | Connection check (explicit) | `exists`, `notExists`, `eq`, `ne` |
-| `responseContains` | Match response body content | `contains` |
+Supported operators: `eq`.
 
 ```terraform
-# Typical usage — property omitted, defaults to connection check
 assertion {
-  source   = "tcp"
+  source   = "certificateValid"
+  operator = "eq"
+  target   = "true"
+}
+```
+
+### `certificateExpiresIn`
+
+Applies to: `ssl_check`
+
+Asserts on the number of days until the SSL certificate expires. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "certificateExpiresIn"
+  operator = "gt"
+  target   = "30"
+}
+```
+
+### `tlsVersion`
+
+Applies to: `ssl_check`
+
+Asserts on the negotiated TLS version. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "tlsVersion"
+  operator = "eq"
+  target   = "1.2"
+}
+```
+
+### `chainValid`
+
+Applies to: `ssl_check`
+
+Asserts whether the SSL certificate chain is valid. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`.
+
+```terraform
+assertion {
+  source   = "chainValid"
+  operator = "eq"
+  target   = "true"
+}
+```
+
+### `cipherSuite`
+
+Applies to: `ssl_check`
+
+Asserts on the negotiated cipher suite. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `contains`.
+
+```terraform
+assertion {
+  source   = "cipherSuite"
+  operator = "eq"
+  target   = "AES256"
+}
+```
+
+### `tcpConnection`
+
+Applies to: `tcp_check`
+
+Asserts on whether a TCP connection was established. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `exists`, `notExists`, `eq`, `ne`.
+
+```terraform
+assertion {
+  source   = "tcpConnection"
+  operator = "exists"
+  target   = "true"
+}
+```
+
+### `responseContains`
+
+Applies to: `tcp_check`
+
+Asserts on the TCP response body content. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `contains`.
+
+```terraform
+assertion {
+  source   = "responseContains"
+  operator = "contains"
+  target   = "PONG"
+}
+```
+
+### `dnsAnswer`
+
+Applies to: `dns_check`
+
+Asserts on the DNS answer record. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `exists`, `notExists`, `eq`, `ne`, `contains`.
+
+```terraform
+assertion {
+  source   = "dnsAnswer"
   operator = "exists"
   target   = "true"
 }
@@ -490,7 +624,7 @@ assertion {
 Required:
 
 - `operator` (String) Comparison operator: `eq`, `ne`, `gt`, `lt`, `contains`, `exists`, `notExists`, `startsWith`, `endsWith`, `regex`, `oneOf`.
-- `source` (String) What to assert on: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`, `ssl`, `tcp`, `dnsAnswer`.
+- `source` (String) What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. SSL/TLS: `ssl` (basic check), or directly: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. TCP: `tcp` (connection check), or directly: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.
 
 Optional:
 

--- a/examples/resources/groundcover_synthetic_test/resource.tf
+++ b/examples/resources/groundcover_synthetic_test/resource.tf
@@ -221,16 +221,14 @@ resource "groundcover_synthetic_test" "ssl_check" {
 
   # Check that the certificate is valid
   assertion {
-    source   = "ssl"
-    property = "certificateValid"
+    source   = "certificateValid"
     operator = "eq"
     target   = "true"
   }
 
   # Check that the certificate expires in more than 30 days
   assertion {
-    source   = "ssl"
-    property = "certificateExpiresIn"
+    source   = "certificateExpiresIn"
     operator = "gt"
     target   = "30"
   }
@@ -251,15 +249,13 @@ resource "groundcover_synthetic_test" "ssl_tls_check" {
   }
 
   assertion {
-    source   = "ssl"
-    property = "certificateValid"
+    source   = "certificateValid"
     operator = "eq"
     target   = "true"
   }
 
   assertion {
-    source   = "ssl"
-    property = "chainValid"
+    source   = "chainValid"
     operator = "eq"
     target   = "true"
   }
@@ -276,7 +272,7 @@ resource "groundcover_synthetic_test" "tcp_check" {
   }
 
   assertion {
-    source   = "tcp"
+    source   = "tcpConnection"
     operator = "exists"
     target   = "true"
   }
@@ -297,7 +293,7 @@ resource "groundcover_synthetic_test" "tcp_send_check" {
   }
 
   assertion {
-    source   = "tcp"
+    source   = "tcpConnection"
     operator = "exists"
     target   = "true"
   }

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -116,6 +116,32 @@ type syntheticAssertionModel struct {
 	Severity types.String `tfsdk:"severity"`
 }
 
+var propertyAsSources = map[string]struct{}{
+	// SSL
+	"certificateValid":     {},
+	"certificateExpiresIn": {},
+	"tlsVersion":           {},
+	"chainValid":           {},
+	"cipherSuite":          {},
+	// TCP
+	"tcpConnection":    {},
+	"responseContains": {},
+}
+
+var baseSources = []string{
+	"statusCode", "responseTime", "responseHeader", "jsonBody", "responseBody",
+	"ssl", "tcp", "dnsAnswer",
+}
+
+func allValidSources() []string {
+	s := make([]string, len(baseSources), len(baseSources)+len(propertyAsSources))
+	copy(s, baseSources)
+	for k := range propertyAsSources {
+		s = append(s, k)
+	}
+	return s
+}
+
 type syntheticRetryModel struct {
 	Count    types.Int64  `tfsdk:"count"`
 	Interval types.String `tfsdk:"interval"`
@@ -377,10 +403,12 @@ func (r *syntheticTestResource) Schema(_ context.Context, _ resource.SchemaReque
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"source": schema.StringAttribute{
-							Description: "What to assert on: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`, `ssl`, `tcp`, `dnsAnswer`.",
-							Required:    true,
+							Description: "What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. " +
+								"SSL/TLS: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. " +
+								"TCP: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.",
+							Required: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("statusCode", "responseTime", "responseHeader", "jsonBody", "responseBody", "ssl", "tcp", "dnsAnswer"),
+								stringvalidator.OneOf(allValidSources()...),
 							},
 						},
 						"operator": schema.StringAttribute{
@@ -649,6 +677,22 @@ func (r *syntheticTestResource) ValidateConfig(ctx context.Context, req resource
 					"The record_type attribute is required and must not be empty when dns_check is configured.",
 				)
 			}
+		}
+	}
+
+	for i, assertion := range config.Assertion {
+		if assertion.Source.IsUnknown() || assertion.Source.IsNull() {
+			continue
+		}
+		src := assertion.Source.ValueString()
+		hasProp := !assertion.Property.IsNull() && !assertion.Property.IsUnknown() && assertion.Property.ValueString() != ""
+
+		if _, ok := propertyAsSources[src]; ok && hasProp {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("assertion").AtListIndex(i).AtName("property"),
+				"Invalid attribute combination",
+				fmt.Sprintf("When source is %q, the property field must not be set — the source already specifies the property.", src),
+			)
 		}
 	}
 

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -403,7 +403,7 @@ func (r *syntheticTestResource) Schema(_ context.Context, _ resource.SchemaReque
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"source": schema.StringAttribute{
-							Description: "What to assert on. HTTP: `statusCode`, `responseTime`, `responseHeader`, `jsonBody`, `responseBody`. " +
+							Description: "What to assert on. All check types: `responseTime`. HTTP: `statusCode`, `responseHeader`, `jsonBody`, `responseBody`. " +
 								"SSL/TLS: `certificateValid`, `certificateExpiresIn`, `tlsVersion`, `chainValid`, `cipherSuite`. " +
 								"TCP: `tcpConnection`, `responseContains`. DNS: `dnsAnswer`.",
 							Required: true,

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -685,7 +685,7 @@ func (r *syntheticTestResource) ValidateConfig(ctx context.Context, req resource
 			continue
 		}
 		src := assertion.Source.ValueString()
-		hasProp := !assertion.Property.IsNull() && !assertion.Property.IsUnknown() && assertion.Property.ValueString() != ""
+		hasProp := !assertion.Property.IsNull() && !assertion.Property.IsUnknown()
 
 		if _, ok := propertyAsSources[src]; ok && hasProp {
 			resp.Diagnostics.AddAttributeError(

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -1502,6 +1502,199 @@ resource "groundcover_synthetic_test" "test" {
 `, name)
 }
 
+func TestAccSyntheticTestResource_sslNewStyleAssertions(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-ssl-newsrc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_sslNewStyleAssertions(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.#", "2"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.source", "certificateValid"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.operator", "eq"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.target", "true"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.1.source", "certificateExpiresIn"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.1.operator", "gt"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.1.target", "30"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+			{
+				ResourceName:            "groundcover_synthetic_test.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ssl_check.sni"},
+			},
+		},
+	})
+}
+
+func TestAccSyntheticTestResource_sslNewStyleApplyLoop(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-ssl-newsrc-loop")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_sslNewStyleAssertions(name),
+			},
+			{
+				Config:   testAccSyntheticTestResourceConfig_sslNewStyleAssertions(name),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccSyntheticTestResourceConfig_sslNewStyleAssertions(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  ssl_check {
+    host = "google.com"
+    port = 443
+  }
+
+  assertion {
+    source   = "certificateValid"
+    operator = "eq"
+    target   = "true"
+  }
+
+  assertion {
+    source   = "certificateExpiresIn"
+    operator = "gt"
+    target   = "30"
+  }
+}
+`, name)
+}
+
+func TestAccSyntheticTestResource_tcpNewStyleConnection(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-tcp-newsrc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_tcpNewStyleConnection(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "tcp_check.host", "google.com"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "tcp_check.port", "443"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.#", "1"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.source", "tcpConnection"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.operator", "exists"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.target", "true"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "groundcover_synthetic_test.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSyntheticTestResource_tcpNewStyleApplyLoop(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-tcp-newsrc-loop")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_tcpNewStyleConnection(name),
+			},
+			{
+				Config:   testAccSyntheticTestResourceConfig_tcpNewStyleConnection(name),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccSyntheticTestResourceConfig_tcpNewStyleConnection(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  tcp_check {
+    host = "google.com"
+    port = 443
+  }
+
+  assertion {
+    source   = "tcpConnection"
+    operator = "exists"
+    target   = "true"
+  }
+}
+`, name)
+}
+
+func TestAccSyntheticTestResource_tcpNewStyleResponseContains(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-tcp-respcontains")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_tcpNewStyleResponseContains(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.#", "1"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.source", "responseContains"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.operator", "contains"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.target", "PONG"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+			{
+				Config:   testAccSyntheticTestResourceConfig_tcpNewStyleResponseContains(name),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccSyntheticTestResourceConfig_tcpNewStyleResponseContains(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  tcp_check {
+    host            = "google.com"
+    port            = 443
+    send            = "PING"
+    expect_response = true
+  }
+
+  assertion {
+    source   = "responseContains"
+    operator = "contains"
+    target   = "PONG"
+  }
+}
+`, name)
+}
+
 func testAccSyntheticTestResourceConfig_tcpUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_synthetic_test" "test" {

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -905,6 +905,38 @@ resource "groundcover_synthetic_test" "test" {
 	})
 }
 
+func TestAccSyntheticTestResource_assertionPropertyAsSourceWithProperty(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-prop-conflict")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  interval = "1m"
+
+  ssl_check {
+    host = "google.com"
+    port = 443
+  }
+
+  assertion {
+    source   = "certificateValid"
+    property = "certificateValid"
+    operator = "eq"
+    target   = "true"
+  }
+}
+`, name),
+				ExpectError: regexp.MustCompile(`property field must not be set`),
+			},
+		},
+	})
+}
+
 func TestAccSyntheticTestResource_notificationMethodConnectedApps(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-synth-ca")
 
@@ -1497,6 +1529,56 @@ resource "groundcover_synthetic_test" "test" {
     property = "certificateExpiresIn"
     operator = "gt"
     target   = "30"
+  }
+}
+`, name)
+}
+
+func TestAccSyntheticTestResource_tcpPropertyAssertions(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-synth-tcp-prop")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSyntheticTestResourceConfig_tcpPropertyAssertions(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "name", name),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.#", "1"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.source", "tcp"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.property", "tcpConnection"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.operator", "exists"),
+					resource.TestCheckResourceAttr("groundcover_synthetic_test.test", "assertion.0.target", "true"),
+					resource.TestCheckResourceAttrSet("groundcover_synthetic_test.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "groundcover_synthetic_test.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSyntheticTestResourceConfig_tcpPropertyAssertions(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_synthetic_test" "test" {
+  name     = %[1]q
+  enabled  = true
+  interval = "1m"
+
+  tcp_check {
+    host = "google.com"
+    port = 443
+  }
+
+  assertion {
+    source   = "tcp"
+    property = "tcpConnection"
+    operator = "exists"
+    target   = "true"
   }
 }
 `, name)

--- a/templates/resources/synthetic_test.md.tmpl
+++ b/templates/resources/synthetic_test.md.tmpl
@@ -16,9 +16,9 @@ description: |-
 
 ## Assertion Source Reference
 
-Each assertion `source` determines what aspect of the check result to evaluate. The table below summarizes which sources are available for each check type, followed by detailed usage for each source.
+Each assertion `source` determines what aspect of the check result to evaluate. The sections below describe which sources are available for each check type, along with detailed usage for each source.
 
-~> **Note:** Starting from version BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
+~> **Note:** Starting from BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
 
 ### `statusCode`
 

--- a/templates/resources/synthetic_test.md.tmpl
+++ b/templates/resources/synthetic_test.md.tmpl
@@ -14,11 +14,47 @@ description: |-
 
 {{ tffile "examples/resources/groundcover_synthetic_test/resource.tf" }}
 
-## Assertion Property Reference
+## Assertion Source Reference
 
-The `property` field in an assertion specifies which property to evaluate within the assertion source. Its usage varies by source:
+Each assertion `source` determines what aspect of the check result to evaluate. The table below summarizes which sources are available for each check type, followed by detailed usage for each source.
+
+~> **Note:** Starting from version BE version 1.11.800, SSL and TCP properties (`certificateValid`, `certificateExpiresIn`, etc.) should be used directly as `source` values. The previous syntax using `source = "ssl"` or `source = "tcp"` with a separate `property` field is still supported and remains fully backwards compatible.
+
+### `statusCode`
+
+Applies to: `http_check`
+
+Asserts on the HTTP response status code. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `ne`, `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "statusCode"
+  operator = "eq"
+  target   = "200"
+}
+```
+
+### `responseTime`
+
+Applies to: `http_check`, `ssl_check`, `tcp_check`, `dns_check`
+
+Asserts on the total response time in milliseconds. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "responseTime"
+  operator = "lt"
+  target   = "5000"
+}
+```
 
 ### `responseHeader`
+
+Applies to: `http_check`
 
 Set `property` to the header name (case-insensitive).
 
@@ -35,6 +71,8 @@ assertion {
 
 ### `jsonBody`
 
+Applies to: `http_check`
+
 Set `property` to a dot-notation path into the JSON response body (e.g. `user.name`, `data.items`).
 
 Supported operators: `exists`, `notExists`, `eq`, `ne`, `contains`.
@@ -50,6 +88,8 @@ assertion {
 
 ### `responseBody`
 
+Applies to: `http_check`
+
 Asserts against the entire raw response body as plain text. The `property` field is not used for this source and should be omitted.
 
 Supported operators: `eq`, `ne`, `contains`, `exists`, `notExists`.
@@ -62,31 +102,129 @@ assertion {
 }
 ```
 
-### `ssl`
+### `certificateValid`
 
-Set `property` to one of the following:
+Applies to: `ssl_check`
 
-| Property | Description | Operators | Target example |
-|---|---|---|---|
-| `certificateValid` | Whether the certificate is valid | `eq` | `true` / `false` |
-| `certificateExpiresIn` | Days until certificate expiry | `gt`, `lt` | `30` |
-| `tlsVersion` | Negotiated TLS version | `eq`, `gt`, `lt` | `1.2` |
-| `chainValid` | Whether the certificate chain is valid | `eq` | `true` / `false` |
-| `cipherSuite` | Negotiated cipher suite | `eq`, `contains` | `AES256` |
+Asserts whether the SSL certificate is valid. The `property` field is not used for this source and should be omitted.
 
-### `tcp`
-
-The `property` field is optional for TCP assertions. When omitted, operators act as connection checks by default.
-
-| Property | Description | Operators |
-|---|---|---|
-| `connection` | Connection check (explicit) | `exists`, `notExists`, `eq`, `ne` |
-| `responseContains` | Match response body content | `contains` |
+Supported operators: `eq`.
 
 ```terraform
-# Typical usage — property omitted, defaults to connection check
 assertion {
-  source   = "tcp"
+  source   = "certificateValid"
+  operator = "eq"
+  target   = "true"
+}
+```
+
+### `certificateExpiresIn`
+
+Applies to: `ssl_check`
+
+Asserts on the number of days until the SSL certificate expires. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "certificateExpiresIn"
+  operator = "gt"
+  target   = "30"
+}
+```
+
+### `tlsVersion`
+
+Applies to: `ssl_check`
+
+Asserts on the negotiated TLS version. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `gt`, `lt`.
+
+```terraform
+assertion {
+  source   = "tlsVersion"
+  operator = "eq"
+  target   = "1.2"
+}
+```
+
+### `chainValid`
+
+Applies to: `ssl_check`
+
+Asserts whether the SSL certificate chain is valid. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`.
+
+```terraform
+assertion {
+  source   = "chainValid"
+  operator = "eq"
+  target   = "true"
+}
+```
+
+### `cipherSuite`
+
+Applies to: `ssl_check`
+
+Asserts on the negotiated cipher suite. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `eq`, `contains`.
+
+```terraform
+assertion {
+  source   = "cipherSuite"
+  operator = "eq"
+  target   = "AES256"
+}
+```
+
+### `tcpConnection`
+
+Applies to: `tcp_check`
+
+Asserts on whether a TCP connection was established. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `exists`, `notExists`, `eq`, `ne`.
+
+```terraform
+assertion {
+  source   = "tcpConnection"
+  operator = "exists"
+  target   = "true"
+}
+```
+
+### `responseContains`
+
+Applies to: `tcp_check`
+
+Asserts on the TCP response body content. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `contains`.
+
+```terraform
+assertion {
+  source   = "responseContains"
+  operator = "contains"
+  target   = "PONG"
+}
+```
+
+### `dnsAnswer`
+
+Applies to: `dns_check`
+
+Asserts on the DNS answer record. The `property` field is not used for this source and should be omitted.
+
+Supported operators: `exists`, `notExists`, `eq`, `ne`, `contains`.
+
+```terraform
+assertion {
+  source   = "dnsAnswer"
   operator = "exists"
   target   = "true"
 }


### PR DESCRIPTION
# User description
## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align synthetic test provider assertions with BE 1.11.800 by treating SSL/TCP property names as <code>source</code> values and blocking redundant <code>property</code> usage. Refresh provider docs, examples, changelog, and acceptance tests to highlight the new syntax while keeping the legacy source-plus-property form supported.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/86?tool=ast&topic=Docs+%26+examples>Docs & examples</a>
        </td><td>Refresh docs, templates, examples, and the changelog to describe the new direct-source syntax and note that the old source-plus-property form still works.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>docs/resources/synthetic_test.md</li>
<li>examples/resources/groundcover_synthetic_test/resource.tf</li>
<li>templates/resources/synthetic_test.md.tmpl</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishel.veksler@groundc...</td><td>Fix dns synthetic's as...</td><td>April 23, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Update CHANGELOG.md</td><td>April 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/86?tool=ast&topic=Assertion+validation>Assertion validation</a>
        </td><td>Validate assertion sources by expanding the allowed <code>source</code> list to include SSL/TCP property names and by rejecting <code>property</code> when those sources are used, ensuring Terraform sends the updated payload shape.<details><summary>Modified files (2)</summary><ul><li>internal/provider/resource_syntheticstest.go</li>
<li>internal/provider/resource_syntheticstest_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishel.veksler@groundc...</td><td>Fix dns synthetic's as...</td><td>April 23, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Merge branch 'main' in...</td><td>April 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/86?tool=ast>(Baz)</a>.