### PR TITLE
INF-1589 Add monitor YAML docs link

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -45,6 +45,8 @@ variable "groundcover_backend_id" {
 }
 
 # Example Monitor: K8s Pod Crash Looping using monitor_yaml
+# Monitor YAML structure docs:
+# https://docs.groundcover.com/use-groundcover/monitors/monitor-yaml-structure
 resource "groundcover_monitor" "k8s_pod_crash_looping" {
   monitor_yaml = <<-YAML
 title: K8s Pod Crash Looping

--- a/examples/resources/groundcover_monitor/resource.tf
+++ b/examples/resources/groundcover_monitor/resource.tf
@@ -30,6 +30,8 @@ variable "groundcover_backend_id" {
 }
 
 # Example Monitor: K8s Pod Crash Looping using monitor_yaml
+# Monitor YAML structure docs:
+# https://docs.groundcover.com/use-groundcover/monitors/monitor-yaml-structure
 resource "groundcover_monitor" "k8s_pod_crash_looping" {
   monitor_yaml = <<-YAML
 title: K8s Pod Crash Looping


### PR DESCRIPTION
# User description
## Summary
- Add the monitor YAML structure documentation link to the `groundcover_monitor` example resource.
- Mirror the example change in the generated monitor resource docs.

## Test plan
- Not run: docs/example comment-only change.
- Attempted `make generate`, but it failed because `terraform` is not installed on PATH in this environment.

Linear: https://linear.app/groundcover/issue/INF-1589/add-monitor-yaml-structure-docs-link-to-terraform-example

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add the monitor YAML structure docs link to the <code>groundcover_monitor</code> Terraform example and its generated resource docs so the example guides users to the monitor configuration schema. Keep the provider docs/examples consistent with the new guidance.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noam@groundcover.com</td><td>INF-1589 add monitor Y...</td><td>May 05, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Quote placeholders in ...</td><td>March 18, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/90?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with direct references to the Monitor YAML structure guide, providing users easier access to detailed information about configuring monitors and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->