### PR TITLE
BE-1622: support day duration units in monitor YAML

### DIFF
--- a/internal/provider/yaml_utils.go
+++ b/internal/provider/yaml_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,17 +30,30 @@ var (
 	componentRegex = regexp.MustCompile(`(\d+)([hms])`)
 	zeroRegex      = regexp.MustCompile(`^0[hms]$`)
 
-	// Match human-readable duration patterns like "10 minutes", "1 hour", "30 seconds"
+	// Match human-readable duration patterns like "10 minutes", "1 hour", "30 seconds", "1 day"
 	// These are converted to Go duration format during normalization
-	humanDurationRegex = regexp.MustCompile(`(\d+)\s+(hours?|minutes?|seconds?)`)
+	humanDurationRegex = regexp.MustCompile(`(\d+)\s+(days?|hours?|minutes?|seconds?)`)
+
+	// Match bare day durations like "1d" or "7d". Day is not a Go duration unit,
+	// so we convert it to hours before time.ParseDuration sees it.
+	// The trailing \b prevents matching the "d" inside composite tokens like "1d12h".
+	dayDurationRegex = regexp.MustCompile(`(\d+)d\b`)
 )
 
 // NormalizeMonitorYaml sorts keys in a YAML string alphabetically using AST manipulation.
 // This approach preserves comments and handles complex YAML structures consistently.
+// It also rewrites duration tokens that Go's time.Duration cannot parse natively
+// (e.g. "1d" -> "24h", "1 day" -> "24h") so downstream SDK unmarshaling succeeds.
 func NormalizeMonitorYaml(ctx context.Context, yamlString string) (string, error) {
 	if yamlString == "" {
 		return "", nil
 	}
+
+	// Convert duration tokens not supported by time.ParseDuration before any
+	// downstream parsing/unmarshaling. Day units in particular ("1d", "2 days")
+	// are accepted by the UI but rejected by Go's time.Duration.
+	yamlString = normalizeHumanDurations(yamlString)
+	yamlString = normalizeDayDurations(yamlString)
 
 	// Parse with AST approach to preserve comments and handle complex structures
 	file, err := parser.ParseBytes([]byte(yamlString), parser.ParseComments)
@@ -320,10 +334,13 @@ func filterAstNodeByKeys(ctx context.Context, node ast.Node, allowedKeys map[str
 }
 
 // NormalizeTimeStringsInYaml normalizes time duration strings in YAML to a consistent format
-// e.g., "30m0s" -> "30m", "1h0m0s" -> "1h", "10 minutes" -> "10m"
+// e.g., "30m0s" -> "30m", "1h0m0s" -> "1h", "10 minutes" -> "10m", "1d" -> "24h"
 func NormalizeTimeStringsInYaml(yamlString string) string {
 	// First convert human-readable durations to Go format
 	yamlString = normalizeHumanDurations(yamlString)
+	// Convert bare day durations (e.g. "1d") to hours, since Go's time.ParseDuration
+	// does not understand the "d" unit.
+	yamlString = normalizeDayDurations(yamlString)
 	result := timeRegex.ReplaceAllStringFunc(yamlString, func(match string) string {
 		// Try to parse as duration to validate it's a valid duration
 		if _, err := time.ParseDuration(match); err == nil {
@@ -711,6 +728,12 @@ func normalizeHumanDurations(s string) string {
 		num := parts[1]
 		unit := parts[2]
 		switch {
+		case strings.HasPrefix(unit, "day"):
+			n, err := strconv.Atoi(num)
+			if err != nil {
+				return match
+			}
+			return strconv.Itoa(n*24) + "h"
 		case strings.HasPrefix(unit, "hour"):
 			return num + "h"
 		case strings.HasPrefix(unit, "minute"):
@@ -723,10 +746,30 @@ func normalizeHumanDurations(s string) string {
 	})
 }
 
+// normalizeDayDurations converts bare day durations like "1d" or "7d" to hours,
+// since Go's time.ParseDuration does not understand the "d" unit.
+// Composite tokens like "1d12h" are not handled here; they require manual
+// conversion by the user.
+func normalizeDayDurations(s string) string {
+	return dayDurationRegex.ReplaceAllStringFunc(s, func(match string) string {
+		parts := dayDurationRegex.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		days, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return match
+		}
+		return strconv.Itoa(days*24) + "h"
+	})
+}
+
 // normalizeTimeString normalizes a single time string
 func normalizeTimeString(s string) string {
 	// First convert human-readable durations to Go format
 	s = normalizeHumanDurations(s)
+	// Convert bare day durations (e.g. "1d") to hours.
+	s = normalizeDayDurations(s)
 	return timeRegex.ReplaceAllStringFunc(s, func(match string) string {
 		// Try to parse as duration to validate it's a valid duration
 		if duration, err := time.ParseDuration(match); err == nil {

--- a/internal/provider/yaml_utils.go
+++ b/internal/provider/yaml_utils.go
@@ -50,10 +50,10 @@ func NormalizeMonitorYaml(ctx context.Context, yamlString string) (string, error
 		return "", nil
 	}
 
-	// Convert duration tokens not supported by time.ParseDuration before any
-	// downstream parsing/unmarshaling. Day units in particular ("1d", "2 days")
-	// are accepted by the UI but rejected by Go's time.Duration.
-	yamlString = normalizeHumanDurations(yamlString)
+	// Convert bare day tokens like "1d" to hours before downstream parsing,
+	// since Go's time.ParseDuration does not accept the "d" unit. Scoped to
+	// "Nd" specifically (not human-readable forms like "1 day") to minimize
+	// the chance of mutating arbitrary free-text fields.
 	yamlString = normalizeDayDurations(yamlString)
 
 	// Parse with AST approach to preserve comments and handle complex structures

--- a/internal/provider/yaml_utils.go
+++ b/internal/provider/yaml_utils.go
@@ -34,11 +34,16 @@ var (
 	// These are converted to Go duration format during normalization
 	humanDurationRegex = regexp.MustCompile(`(\d+)\s+(days?|hours?|minutes?|seconds?)`)
 
-	// Match bare day durations like "1d" or "7d". Day is not a Go duration unit,
-	// so we convert it to hours before time.ParseDuration sees it.
-	// Word boundaries on both sides prevent matching digits inside identifiers
-	// (e.g. "field1d") or composite duration tokens (e.g. "1d12h").
-	dayDurationRegex = regexp.MustCompile(`\b(\d+)d\b`)
+	// Match day durations like "1d", "7d", "1d4h", "2d12h30m", "1d30s". Day is not
+	// a Go duration unit, so we convert it (and merge into any trailing hours) before
+	// time.ParseDuration sees it. The left word boundary prevents matching digits
+	// inside identifiers (e.g. "field1d"); the right boundary ensures the trailing
+	// unit is a complete token (e.g. "1dhours" or "1d12hours" do not match).
+	dayDurationRegex = regexp.MustCompile(`\b(\d+)d((?:\d+h)?(?:\d+m)?(?:\d+s)?)\b`)
+
+	// Extracts a leading hours component from a day-duration suffix so we can
+	// fold the days-converted-to-hours into it (e.g. "1d4h" -> "28h").
+	daySuffixHoursRegex = regexp.MustCompile(`^(\d+)h`)
 )
 
 // NormalizeMonitorYaml sorts keys in a YAML string alphabetically using AST manipulation.
@@ -50,10 +55,10 @@ func NormalizeMonitorYaml(ctx context.Context, yamlString string) (string, error
 		return "", nil
 	}
 
-	// Convert bare day tokens like "1d" to hours before downstream parsing,
-	// since Go's time.ParseDuration does not accept the "d" unit. Scoped to
-	// "Nd" specifically (not human-readable forms like "1 day") to minimize
-	// the chance of mutating arbitrary free-text fields.
+	// Convert day tokens like "1d" or composite forms like "1d4h" into Go
+	// duration format before downstream parsing, since time.ParseDuration does
+	// not accept the "d" unit. Human-readable forms ("1 day") are handled
+	// separately by normalizeHumanDurations to avoid mutating free-text fields.
 	yamlString = normalizeDayDurations(yamlString)
 
 	// Parse with AST approach to preserve comments and handle complex structures
@@ -747,21 +752,31 @@ func normalizeHumanDurations(s string) string {
 	})
 }
 
-// normalizeDayDurations converts bare day durations like "1d" or "7d" to hours,
-// since Go's time.ParseDuration does not understand the "d" unit.
-// Composite tokens like "1d12h" are not handled here; they require manual
-// conversion by the user.
+// normalizeDayDurations converts day durations like "1d", "7d", "1d4h", or
+// "2d12h30m" into Go duration format by converting days to hours and merging
+// with any trailing hours component. Go's time.ParseDuration does not
+// understand the "d" unit, so this rewriting must happen before parsing.
 func normalizeDayDurations(s string) string {
 	return dayDurationRegex.ReplaceAllStringFunc(s, func(match string) string {
 		parts := dayDurationRegex.FindStringSubmatch(match)
-		if len(parts) != 2 {
+		if len(parts) != 3 {
 			return match
 		}
 		days, err := strconv.Atoi(parts[1])
 		if err != nil {
 			return match
 		}
-		return strconv.Itoa(days*24) + "h"
+		totalHours := days * 24
+		suffix := parts[2]
+		if hMatch := daySuffixHoursRegex.FindStringSubmatch(suffix); hMatch != nil {
+			h, err := strconv.Atoi(hMatch[1])
+			if err != nil {
+				return match
+			}
+			totalHours += h
+			suffix = suffix[len(hMatch[0]):]
+		}
+		return strconv.Itoa(totalHours) + "h" + suffix
 	})
 }
 

--- a/internal/provider/yaml_utils.go
+++ b/internal/provider/yaml_utils.go
@@ -36,8 +36,9 @@ var (
 
 	// Match bare day durations like "1d" or "7d". Day is not a Go duration unit,
 	// so we convert it to hours before time.ParseDuration sees it.
-	// The trailing \b prevents matching the "d" inside composite tokens like "1d12h".
-	dayDurationRegex = regexp.MustCompile(`(\d+)d\b`)
+	// Word boundaries on both sides prevent matching digits inside identifiers
+	// (e.g. "field1d") or composite duration tokens (e.g. "1d12h").
+	dayDurationRegex = regexp.MustCompile(`\b(\d+)d\b`)
 )
 
 // NormalizeMonitorYaml sorts keys in a YAML string alphabetically using AST manipulation.

--- a/internal/provider/yaml_utils.go
+++ b/internal/provider/yaml_utils.go
@@ -34,16 +34,14 @@ var (
 	// These are converted to Go duration format during normalization
 	humanDurationRegex = regexp.MustCompile(`(\d+)\s+(days?|hours?|minutes?|seconds?)`)
 
-	// Match day durations like "1d", "7d", "1d4h", "2d12h30m", "1d30s". Day is not
-	// a Go duration unit, so we convert it (and merge into any trailing hours) before
-	// time.ParseDuration sees it. The left word boundary prevents matching digits
-	// inside identifiers (e.g. "field1d"); the right boundary ensures the trailing
-	// unit is a complete token (e.g. "1dhours" or "1d12hours" do not match).
-	dayDurationRegex = regexp.MustCompile(`\b(\d+)d((?:\d+h)?(?:\d+m)?(?:\d+s)?)\b`)
-
-	// Extracts a leading hours component from a day-duration suffix so we can
-	// fold the days-converted-to-hours into it (e.g. "1d4h" -> "28h").
-	daySuffixHoursRegex = regexp.MustCompile(`^(\d+)h`)
+	// Match day durations like "1d", "7d", or "1d4h". Day is not a Go duration
+	// unit, so we convert it (and merge into any trailing hours) before
+	// time.ParseDuration sees it. Forms with minutes or seconds (e.g. "1d30m")
+	// are intentionally not supported and are left for time.ParseDuration to
+	// reject downstream. The left word boundary prevents matching digits inside
+	// identifiers (e.g. "field1d"); the right boundary ensures the trailing
+	// unit is a complete token.
+	dayDurationRegex = regexp.MustCompile(`\b(\d+)d(?:(\d+)h)?\b`)
 )
 
 // NormalizeMonitorYaml sorts keys in a YAML string alphabetically using AST manipulation.
@@ -752,10 +750,10 @@ func normalizeHumanDurations(s string) string {
 	})
 }
 
-// normalizeDayDurations converts day durations like "1d", "7d", "1d4h", or
-// "2d12h30m" into Go duration format by converting days to hours and merging
-// with any trailing hours component. Go's time.ParseDuration does not
-// understand the "d" unit, so this rewriting must happen before parsing.
+// normalizeDayDurations converts day durations like "1d", "7d", or "1d4h"
+// into hours, since Go's time.ParseDuration does not understand the "d" unit.
+// Composite forms with minutes/seconds (e.g. "1d30m") are not supported and
+// will fail downstream parsing — users should write "24h30m" instead.
 func normalizeDayDurations(s string) string {
 	return dayDurationRegex.ReplaceAllStringFunc(s, func(match string) string {
 		parts := dayDurationRegex.FindStringSubmatch(match)
@@ -767,16 +765,14 @@ func normalizeDayDurations(s string) string {
 			return match
 		}
 		totalHours := days * 24
-		suffix := parts[2]
-		if hMatch := daySuffixHoursRegex.FindStringSubmatch(suffix); hMatch != nil {
-			h, err := strconv.Atoi(hMatch[1])
+		if parts[2] != "" {
+			h, err := strconv.Atoi(parts[2])
 			if err != nil {
 				return match
 			}
 			totalHours += h
-			suffix = suffix[len(hMatch[0]):]
 		}
-		return strconv.Itoa(totalHours) + "h" + suffix
+		return strconv.Itoa(totalHours) + "h"
 	})
 }
 

--- a/internal/provider/yaml_utils_test.go
+++ b/internal/provider/yaml_utils_test.go
@@ -375,6 +375,21 @@ func TestNormalizeTimeString(t *testing.T) {
 			input:    "interval: 5m0s and pendingFor: 30m0s",
 			expected: "interval: 5m and pendingFor: 30m",
 		},
+		{
+			name:     "1d should normalize to 24h",
+			input:    "1d",
+			expected: "24h",
+		},
+		{
+			name:     "7d should normalize to 168h",
+			input:    "7d",
+			expected: "168h",
+		},
+		{
+			name:     "pendingFor with 1d",
+			input:    "pendingFor: 1d",
+			expected: "pendingFor: 24h",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1358,6 +1373,8 @@ func TestNormalizeHumanDurations(t *testing.T) {
 		{"2 hours", "2h"},
 		{"30 seconds", "30s"},
 		{"1 second", "1s"},
+		{"1 day", "24h"},
+		{"2 days", "48h"},
 		{"no duration here", "no duration here"},
 		{"10m", "10m"},
 		{"1h30m", "1h30m"},

--- a/internal/provider/yaml_utils_test.go
+++ b/internal/provider/yaml_utils_test.go
@@ -395,6 +395,41 @@ func TestNormalizeTimeString(t *testing.T) {
 			input:    "name: field1d",
 			expected: "name: field1d",
 		},
+		{
+			name:     "1d4h should normalize to 28h",
+			input:    "1d4h",
+			expected: "28h",
+		},
+		{
+			name:     "2d12h30m should normalize to 60h30m",
+			input:    "2d12h30m",
+			expected: "60h30m",
+		},
+		{
+			name:     "1d30m should normalize to 24h30m",
+			input:    "1d30m",
+			expected: "24h30m",
+		},
+		{
+			name:     "1d30s should normalize to 24h30s",
+			input:    "1d30s",
+			expected: "24h30s",
+		},
+		{
+			name:     "pendingFor with 1d4h",
+			input:    "pendingFor: 1d4h",
+			expected: "pendingFor: 28h",
+		},
+		{
+			name:     "composite inside identifier should not be mutated",
+			input:    "name: field1d4h",
+			expected: "name: field1d4h",
+		},
+		{
+			name:     "1d followed by hours word should not match composite",
+			input:    "duration: 1dhours",
+			expected: "duration: 1dhours",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/provider/yaml_utils_test.go
+++ b/internal/provider/yaml_utils_test.go
@@ -390,6 +390,11 @@ func TestNormalizeTimeString(t *testing.T) {
 			input:    "pendingFor: 1d",
 			expected: "pendingFor: 24h",
 		},
+		{
+			name:     "digits inside identifier should not be mutated",
+			input:    "name: field1d",
+			expected: "name: field1d",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/provider/yaml_utils_test.go
+++ b/internal/provider/yaml_utils_test.go
@@ -401,19 +401,9 @@ func TestNormalizeTimeString(t *testing.T) {
 			expected: "28h",
 		},
 		{
-			name:     "2d12h30m should normalize to 60h30m",
-			input:    "2d12h30m",
-			expected: "60h30m",
-		},
-		{
-			name:     "1d30m should normalize to 24h30m",
-			input:    "1d30m",
-			expected: "24h30m",
-		},
-		{
-			name:     "1d30s should normalize to 24h30s",
-			input:    "1d30s",
-			expected: "24h30s",
+			name:     "2d12h should normalize to 60h",
+			input:    "2d12h",
+			expected: "60h",
 		},
 		{
 			name:     "pendingFor with 1d4h",


### PR DESCRIPTION
# User description
Go's time.ParseDuration does not accept the "d" unit, so monitor YAML containing values like "pendingFor: 1d" failed to unmarshal into the SDK request model even though the UI accepts day-based durations.

Convert "Nd" and "N day(s)" tokens to hours during NormalizeMonitorYaml so the create/update path succeeds, and apply the same conversion in the comparison path so semantic compare does not flag drift.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] I have written acceptance tests for my changes
- [ ] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [ ] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Convert day-based duration tokens such as <code>1d</code> or <code>1 day</code> into hour-based durations before YAML normalization so Terraform monitor creation accepts the same inputs as the UI. Apply this conversion in <code>NormalizeMonitorYaml</code> and supporting helpers to keep comparison paths aligned with the normalized representation and avoid false drift.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/94?tool=ast&topic=Normalization+tests>Normalization tests</a>
        </td><td>Verify <code>TestNormalizeTimeString</code> and <code>TestNormalizeHumanDurations</code> cover the new day-duration parsing, composites, and identifier-guard cases.<details><summary>Modified files (1)</summary><ul><li>internal/provider/yaml_utils_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>BE-1622: limit day-dur...</td><td>May 11, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>fix: Mark Terraform-ma...</td><td>May 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/94?tool=ast&topic=Duration+normalization>Duration normalization</a>
        </td><td>Convert day-based tokens through <code>normalizeDayDurations</code> and <code>normalizeHumanDurations</code> so <code>NormalizeMonitorYaml</code> handles <code>1d</code>/<code>N day(s)</code> inputs before building monitor requests.<details><summary>Modified files (1)</summary><ul><li>internal/provider/yaml_utils.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>BE-1622: limit day-dur...</td><td>May 11, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>fix: Mark Terraform-ma...</td><td>May 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/94?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YAML duration parsing now recognizes day-based formats (e.g., "1d", "1 day", "2 days") and mixed day/hour forms (e.g., "1d4h"), normalizing them to hours (e.g., "24h", "28h") for consistent validation and processing.

* **Tests**
  * Added tests verifying day-based and mixed duration normalization and ensuring day-like substrings in identifiers remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groundcover-com/terraform-provider-groundcover/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->