### PR TITLE
BE-1625: document admin SA requirement for groundcover_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.2
+
+* Documented that managing `groundcover_secret` resources (create, update, delete) requires a service account with the **admin** role — clarifies the permission requirement that previously surfaced only as an API error
+
 ## 1.13.1
 
 * Documentation fix for `Monitor` resource examples

--- a/docs/resources/metricspipeline.md
+++ b/docs/resources/metricspipeline.md
@@ -48,6 +48,7 @@ Optional:
 - `drop_regex` (List of String) List of regex patterns. Metrics whose __name__ matches any pattern are dropped.
 - `keep_regex` (List of String) List of regex patterns. Only metrics whose __name__ matches at least one pattern are kept. All others are dropped.
 - `raw` (String) Raw VictoriaMetrics relabeling rules in YAML format for advanced use cases.
+- `remove_label` (List of String) List of label names to remove from every metric. Be careful with this setting as it can cause metrics amalgamation.
 
 ## Import
 

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Manages a groundcover Secret.
   Secrets allow you to securely store sensitive values (like API keys, passwords, or credentials) and receive a reference ID that can be used in other resources (such as data integrations) as a placeholder instead of the actual secret value.
+  Permissions: Managing secrets (create, update, delete) requires a service account with the admin role. Service accounts with read or write roles cannot manage secrets and will receive a permission error from the API.
   Note: The secret content is write-only and is NOT persisted in Terraform state. It is only sent to the API during create and update operations and cannot be retrieved afterward.
 ---
 
@@ -13,6 +14,8 @@ description: |-
 Manages a groundcover Secret.
 
 Secrets allow you to securely store sensitive values (like API keys, passwords, or credentials) and receive a reference ID that can be used in other resources (such as data integrations) as a placeholder instead of the actual secret value.
+
+**Permissions:** Managing secrets (create, update, delete) requires a service account with the **admin** role. Service accounts with read or write roles cannot manage secrets and will receive a permission error from the API.
 
 **Note:** The secret content is write-only and is NOT persisted in Terraform state. It is only sent to the API during create and update operations and cannot be retrieved afterward.
 

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -51,6 +51,8 @@ func (r *secretResource) Schema(ctx context.Context, req resource.SchemaRequest,
 
 Secrets allow you to securely store sensitive values (like API keys, passwords, or credentials) and receive a reference ID that can be used in other resources (such as data integrations) as a placeholder instead of the actual secret value.
 
+**Permissions:** Managing secrets (create, update, delete) requires a service account with the **admin** role. Service accounts with read or write roles cannot manage secrets and will receive a permission error from the API.
+
 **Note:** The secret content is write-only and is NOT persisted in Terraform state. It is only sent to the API during create and update operations and cannot be retrieved afterward.`,
 
 		Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
# User description
## Summary

- Add a permissions note to the `groundcover_secret` resource description so users know that managing secrets (create/update/delete) requires a service account with the **admin** role.
- Customers had been discovering this requirement only after hitting API permission errors. Asked by Arie in Slack ([thread](https://groundcovercom.slack.com/archives/C07T5030CSV/p1778005164672789)).
- Linear: [BE-1625](https://linear.app/groundcover/issue/BE-1625/terraform-provider-or-document-admin-service-account-requirement-for)

## Changes

- `internal/provider/resource_secret.go`: extended `MarkdownDescription` with a **Permissions** section.
- `docs/resources/secret.md`: regenerated via `make generate`.
- `CHANGELOG.md`: added entry under new `1.13.2` section (latest tag is `v1.13.1`).
- `docs/resources/metricspipeline.md`: incidentally regenerated — picks up the `remove_label` attribute that was already in the schema but missing from committed docs.

## Test plan

- [x] `make generate` regenerates docs cleanly.
- [ ] Verify rendered `docs/resources/secret.md` reads well in the Terraform Registry preview.

## Checklist

- [ ] I have written acceptance tests for my changes — N/A, docs-only change
- [x] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality — N/A, docs-only change
- [ ] I have updated the README.md with details of changes — README does not document per-resource permissions
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Highlight that <code>groundcover_secret</code> operations require an admin-role service account by enriching the provider schema metadata and regenerated docs. Document the permission constraint in the Terraform changelog so users know to use admin service accounts before hitting API errors.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>BE-1625: document admi...</td><td>May 10, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>chore: add missing cha...</td><td>May 06, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/95?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration option to remove labels from metrics in the metrics pipeline.

* **Documentation**
  * Updated resource documentation and changelog to clarify the admin role requirement for managing secrets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groundcover-com/terraform-provider-groundcover/pull/95)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->