### PR TITLE
Add CODEOWNERS file with designated owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* bertinm-gc AvitalTamir

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* bertinm-gc AvitalTamir
+* bertin@groundcover.com avital@groundcover.com


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add CODEOWNERS entry to designate <code>bertin</code> and <code>avital</code> as responsible for Terraform Provider changes. Ensure reviews route to the designated owners by updating the root CODEOWNERS configuration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>Update CODEOWNERS emai...</td><td>May 26, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/96?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership configuration to set a single global ownership rule, consolidating responsibility for all paths under specified maintainers. This is an administrative change with no functional impact on end-user behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groundcover-com/terraform-provider-groundcover/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->