### PR TITLE
BE-1851: improve groundcover_policy UX (import docs, role docs, error message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.13.4
+
+* Documented that `groundcover_policy` import takes the policy **UUID** (not the name) — the import example and generated docs now show a UUID placeholder and point at the UI/network tab for finding it
+* Documented the allowed keys in the `groundcover_policy` `role` map (`read`, `write`, `admin`) in the schema description so they appear in the generated docs; the value is unused on the backend
+* Added schema validation for the `groundcover_policy` `role` map — the provider now rejects invalid keys (`read`, `write`, and `admin` are the only accepted values) at plan time with a clear error, rather than propagating an opaque 400 from the backend
+
 ## 1.13.3
 
 * Fixed wrong parsing of time duration in monitors (1d and complex formats like 1h30m)

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -97,7 +97,7 @@ output "policy_revision_number" {
 ### Required
 
 - `name` (String) The name of the policy.
-- `role` (Map of String) Role definitions associated with the policy. Maps role identifiers to specific permissions or access levels.
+- `role` (Map of String) Role definitions associated with the policy. The map **key** is the access level granted to the policy and must be one of `read`, `write`, or `admin`. The map **value** is unused on the backend — pass any non-empty string (e.g. the role key itself). Example: `role = { admin = "admin" }`.
 
 ### Optional
 
@@ -334,5 +334,8 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-terraform import groundcover_policy.example "<id>"
+# Policies are imported by their UUID, not their name.
+# Find the UUID under Settings → Policies (visible in the network tab of the policy list request),
+# or copy it from `groundcover_policy.<name>.uuid` after creating one with Terraform.
+terraform import groundcover_policy.example "00000000-0000-0000-0000-000000000000"
 ```

--- a/examples/resources/groundcover_policy/import.sh
+++ b/examples/resources/groundcover_policy/import.sh
@@ -1,1 +1,4 @@
-terraform import groundcover_policy.example "<id>"
+# Policies are imported by their UUID, not their name.
+# Find the UUID under Settings → Policies (visible in the network tab of the policy list request),
+# or copy it from `groundcover_policy.<name>.uuid` after creating one with Terraform.
+terraform import groundcover_policy.example "00000000-0000-0000-0000-000000000000"

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -20,6 +20,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	// Validator imports
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	// SDK Imports
 	"github.com/groundcover-com/groundcover-sdk-go/pkg/models"
 )
@@ -180,9 +185,12 @@ func (r *policyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Required:            true,
 			},
 			"role": schema.MapAttribute{
-				MarkdownDescription: "Role definitions associated with the policy. Maps role identifiers to specific permissions or access levels.",
+				MarkdownDescription: "Role definitions associated with the policy. The map **key** is the access level granted to the policy and must be one of `read`, `write`, or `admin`. The map **value** is unused on the backend — pass any non-empty string (e.g. the role key itself). Example: `role = { admin = \"admin\" }`.",
 				ElementType:         types.StringType,
 				Required:            true,
+				Validators: []validator.Map{
+					mapvalidator.KeysAre(stringvalidator.OneOf("read", "write", "admin")),
+				},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "A description for the policy.",


### PR DESCRIPTION
# User description
## Summary

Customer hit three UX issues with \`groundcover_policy\` that made the resource feel broken even though the API was working as designed. Linear: [BE-1851](https://linear.app/groundcover/issue/BE-1851/policy-or-improve-groundcover-policy-terraform-resource-ux-import-docs).

- **Import docs misleading.** \`terraform import groundcover_policy.x "<name>"\` returns a bare 400 from \`GET /api/rbac/policy/{id}\` — import takes the policy UUID, not the name (unlike e.g. ingestion keys). Updated \`examples/resources/groundcover_policy/import.sh\` to show a UUID placeholder and a short note on where to find it; the regenerated docs pick this up automatically.

- **\`role\` map keys undocumented and unvalidated.** Schema description said "Maps role identifiers to specific permissions or access levels" — no mention that keys must be one of \`read\`/\`write\`/\`admin\` (the value is unused). Customer tried arbitrary keys/values and got a bare opaque 400 from the backend. Fixed in two ways:
  - Schema \`MarkdownDescription\` now states the constraint (reaches generated docs).
  - Added \`mapvalidator.KeysAre(stringvalidator.OneOf("read", "write", "admin"))\` to the \`role\` attribute, so Terraform rejects invalid keys at **plan time** with a clear error — no API call needed.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/provider\` — all unit tests pass
- [x] Manually verified validator fires: \`Attribute ["testrole1"] value must be one of: ["read" "write" "admin"], got: "testrole1"\`
- [x] \`make fmt\` clean
- [x] \`make generate\` — \`docs/resources/policy.md\` reflects schema and import-script changes

## Checklist

- [ ] I have written acceptance tests for my changes — _N/A; docs + schema validator. The validator is covered by the framework's own test suite; existing CRUD/disappears/regression acceptance tests still cover the resource._
- [x] I have run \`make generate\` to update generated docs
- [x] I have added examples demonstrating the new functionality — updated \`examples/resources/groundcover_policy/import.sh\`
- [ ] I have updated the README.md with details of changes — _N/A; per-resource lists already include \`groundcover_policy\`, no new resource or attribute_
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify groundcover_policy import and changelog guidance so docs and the example script explain the UUID requirement and where to copy it from. Document the role map schema updates and validator addition to enforce read/write/admin keys and prevent opaque policy creation errors.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/99?tool=ast&topic=Import+UX>Import UX</a>
        </td><td>Describe how groundcover_policy imports require the UUID in docs, changelog, and the import script so operators know where to locate it.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>docs/resources/policy.md</li>
<li>examples/resources/groundcover_policy/import.sh</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>BE-1851: improve groun...</td><td>May 27, 2026</td></tr>
<tr><td>yuvco1@gmail.com</td><td>Add changelog + update...</td><td>May 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/99?tool=ast&topic=Role+validation>Role validation</a>
        </td><td>Enforce the role map key constraints in the schema, add a validator, and expand the description so generated docs warn about read/write/admin keys and unused values.<details><summary>Modified files (1)</summary><ul><li>internal/provider/resource_policy.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>BE-1851: improve groun...</td><td>May 27, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>fix linter</td><td>December 04, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/99?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated import documentation to clarify policies import by UUID (not name); added UUID-format examples.

* **Improvements**
  * Added schema validation for policy role attribute keys (read, write, admin), rejecting invalid keys at plan time with clear error messages instead of backend failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groundcover-com/terraform-provider-groundcover/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->