### PR TITLE
BE-2124: fix monitor v2 reserved annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.14.1
 
+* Fixed `groundcover_monitor_v2` import/update failures caused by sending the reserved `_gc_monitor_v2_query_type` annotation back to the monitors API
 * Added computed `data_hash` attribute to `groundcover_connected_app` — exposes the SHA-256 hash groundcover computes over the stored (pre-redaction) data, so Terraform can detect changes to the sensitive, redacted `data` without retrieving the secret
 * `groundcover_connected_app` now corrects out-of-band drift: when the API-reported `data_hash` differs from the value recorded in state, the next plan shows a diff and apply restores the configured `data`. Detection is forward-looking — it covers changes made after the baseline hash is first recorded in state (on the first refresh after upgrading to this version); resources created by an older provider adopt the current server hash as their baseline, so pre-upgrade out-of-band changes are not retroactively flagged
 * Updated `github.com/groundcover-com/groundcover-sdk-go` to `v1.291.0` (adds `data_hash` to connected-app responses)

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -332,7 +332,7 @@ resource "groundcover_monitor_v2" "raw_sql" {
 
 ### Optional
 
-- `annotations` (Map of String) Annotations to attach to the monitor and resulting alerts. The `_gc_monitor_v2_query_type` key is reserved for provider-managed Monitor V2 state and cannot be configured.
+- `annotations` (Map of String) Annotations to attach to the monitor and resulting alerts. The `_gc_monitor_v2_query_type` and `_gc_data_type` keys are reserved for provider-managed Monitor V2 state and cannot be configured.
 - `auto_resolve` (Boolean) Whether the monitor should auto-resolve.
 - `category` (String) Monitor category.
 - `display` (Block, Optional) Display metadata shown in monitor issues. (see [below for nested schema](#nestedblock--display))

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -92,9 +92,7 @@ func TestMonitorV2BuildCreateRequestGCQL(t *testing.T) {
 	if query.InstantRollup != "5m" {
 		t.Fatalf("query.InstantRollup = %q, want 5m", query.InstantRollup)
 	}
-	if req.Annotations[monitorV2QueryTypeAnnotationKey] != monitorV2QueryTypeGCQL {
-		t.Fatalf("Annotations[%q] = %q, want %q", monitorV2QueryTypeAnnotationKey, req.Annotations[monitorV2QueryTypeAnnotationKey], monitorV2QueryTypeGCQL)
-	}
+	requireNoInternalMonitorV2Annotations(t, req.Annotations)
 }
 
 func TestMonitorV2BuildCreateRequestMetricsQL(t *testing.T) {
@@ -128,9 +126,7 @@ func TestMonitorV2BuildCreateRequestMetricsQL(t *testing.T) {
 	if time.Duration(query.Rollup.Time) != 5*time.Minute {
 		t.Fatalf("query.Rollup.Time = %s, want 5m", time.Duration(query.Rollup.Time))
 	}
-	if req.Annotations[monitorV2QueryTypeAnnotationKey] != monitorV2QueryTypeMetricsQL {
-		t.Fatalf("Annotations[%q] = %q, want %q", monitorV2QueryTypeAnnotationKey, req.Annotations[monitorV2QueryTypeAnnotationKey], monitorV2QueryTypeMetricsQL)
-	}
+	requireNoInternalMonitorV2Annotations(t, req.Annotations)
 }
 
 func TestMonitorV2BuildCreateRequestRawSQL(t *testing.T) {
@@ -155,8 +151,36 @@ func TestMonitorV2BuildCreateRequestRawSQL(t *testing.T) {
 	if query.Rollup != nil {
 		t.Fatalf("query.Rollup = %#v, want nil", query.Rollup)
 	}
-	if req.Annotations[monitorV2QueryTypeAnnotationKey] != monitorV2QueryTypeRawSQL {
-		t.Fatalf("Annotations[%q] = %q, want %q", monitorV2QueryTypeAnnotationKey, req.Annotations[monitorV2QueryTypeAnnotationKey], monitorV2QueryTypeRawSQL)
+	requireNoInternalMonitorV2Annotations(t, req.Annotations)
+}
+
+func TestMonitorV2BuildUpdateRequestFiltersInternalAnnotations(t *testing.T) {
+	ctx := context.Background()
+	plan := testMonitorV2BasePlan(t, &monitorV2QueryModel{
+		Type:       types.StringValue(monitorV2QueryTypeMetricsQL),
+		Expression: types.StringValue(`sum(up) by (cluster)`),
+		Rollup: &monitorV2RollupModel{
+			Function: types.StringValue("last"),
+			Time:     types.StringValue("5m"),
+		},
+	})
+	annotations, mapDiags := types.MapValueFrom(ctx, types.StringType, map[string]string{
+		monitorV2QueryTypeAnnotationKey: monitorV2QueryTypeMetricsQL,
+		monitorV2DataTypeAnnotationKey:  "metrics",
+		"team":                          "platform",
+	})
+	if mapDiags.HasError() {
+		t.Fatalf("types.MapValueFrom() diagnostics: %v", mapDiags)
+	}
+	plan.Annotations = annotations
+
+	req, diags := buildMonitorV2UpdateRequest(ctx, &plan)
+	if diags.HasError() {
+		t.Fatalf("buildMonitorV2UpdateRequest() diagnostics: %v", diags)
+	}
+	requireNoInternalMonitorV2Annotations(t, req.Annotations)
+	if req.Annotations["team"] != "platform" {
+		t.Fatalf("Annotations[team] = %q, want platform", req.Annotations["team"])
 	}
 }
 
@@ -602,35 +626,49 @@ func TestMonitorV2MapSDKToModelUsesQueryTypeAnnotation(t *testing.T) {
 	}
 }
 
-func TestMonitorV2FilterAnnotationsRemovesInternalQueryTypeMarker(t *testing.T) {
+func TestMonitorV2FilterAnnotationsRemovesInternalMarkers(t *testing.T) {
 	filtered := monitorV2FilterAnnotations(map[string]string{
 		monitorV2QueryTypeAnnotationKey: monitorV2QueryTypeMetricsQL,
-		"_gc_data_type":                 "metrics",
+		monitorV2DataTypeAnnotationKey:  "metrics",
 		"team":                          "platform",
 	})
 	if _, ok := filtered[monitorV2QueryTypeAnnotationKey]; ok {
 		t.Fatalf("filtered annotations still include %q", monitorV2QueryTypeAnnotationKey)
 	}
-	if _, ok := filtered["_gc_data_type"]; ok {
-		t.Fatalf("filtered annotations still include _gc_data_type")
+	if _, ok := filtered[monitorV2DataTypeAnnotationKey]; ok {
+		t.Fatalf("filtered annotations still include %q", monitorV2DataTypeAnnotationKey)
 	}
 	if filtered["team"] != "platform" {
 		t.Fatalf("filtered team annotation = %q, want platform", filtered["team"])
 	}
 }
 
-func TestMonitorV2ValidateAnnotationsRejectsReservedQueryTypeMarker(t *testing.T) {
-	annotations, mapDiags := types.MapValueFrom(context.Background(), types.StringType, map[string]string{
-		monitorV2QueryTypeAnnotationKey: monitorV2QueryTypeGCQL,
-		"team":                          "platform",
-	})
-	if mapDiags.HasError() {
-		t.Fatalf("types.MapValueFrom() diagnostics: %v", mapDiags)
-	}
+func TestMonitorV2ValidateAnnotationsRejectsReservedInternalMarkers(t *testing.T) {
+	for _, key := range []string{monitorV2QueryTypeAnnotationKey, monitorV2DataTypeAnnotationKey} {
+		t.Run(key, func(t *testing.T) {
+			annotations, mapDiags := types.MapValueFrom(context.Background(), types.StringType, map[string]string{
+				key:    monitorV2QueryTypeGCQL,
+				"team": "platform",
+			})
+			if mapDiags.HasError() {
+				t.Fatalf("types.MapValueFrom() diagnostics: %v", mapDiags)
+			}
 
-	var diags diag.Diagnostics
-	monitorV2ValidateAnnotations(annotations, &diags)
-	requireDiagnosticSummary(t, diags, "Reserved monitor annotation")
+			var diags diag.Diagnostics
+			monitorV2ValidateAnnotations(annotations, &diags)
+			requireDiagnosticSummary(t, diags, "Reserved monitor annotation")
+		})
+	}
+}
+
+func requireNoInternalMonitorV2Annotations(t *testing.T, annotations map[string]string) {
+	t.Helper()
+
+	for key := range annotations {
+		if monitorV2IsInternalAnnotation(key) {
+			t.Fatalf("annotations unexpectedly include internal key %q", key)
+		}
+	}
 }
 
 func TestMonitorResourceDisappearsDefaultAPIURLMatchesProviderDefault(t *testing.T) {
@@ -771,6 +809,40 @@ func TestAccMonitorV2Resource(t *testing.T) {
 	})
 }
 
+func TestAccMonitorV2Resource_importThenUpdate(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-monitor-v2-import")
+	updatedName := acctest.RandomWithPrefix("test-monitor-v2-import-updated")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorV2MetricsQLImportUpdateConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("groundcover_monitor_v2.test", "id"),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "title", name),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "query.type", monitorV2QueryTypeMetricsQL),
+					resource.TestCheckNoResourceAttr("groundcover_monitor_v2.test", "annotations."+monitorV2QueryTypeAnnotationKey),
+				),
+			},
+			{
+				ResourceName:      "groundcover_monitor_v2.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMonitorV2MetricsQLImportUpdateConfig(updatedName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "title", updatedName),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "display.header", updatedName),
+					resource.TestCheckNoResourceAttr("groundcover_monitor_v2.test", "annotations."+monitorV2QueryTypeAnnotationKey),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMonitorV2Resource_disappears(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-monitor-v2")
 
@@ -866,6 +938,51 @@ resource "groundcover_monitor_v2" "test" {
 
   execution_error_state = "OK"
   no_data_state         = "OK"
+}
+`, name)
+}
+
+func testAccMonitorV2MetricsQLImportUpdateConfig(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_monitor_v2" "test" {
+  title            = %[1]q
+  severity         = "warning"
+  measurement_type = "state"
+  is_paused        = true
+
+  display {
+    header      = %[1]q
+    description = "Monitor V2 import/update acceptance test"
+  }
+
+  query {
+    type       = "metricsql"
+    expression = "sum(groundcover_kube_pod_container_status_running{})"
+
+    rollup {
+      function = "avg"
+      time     = "5m"
+    }
+  }
+
+  threshold {
+    name       = "threshold_1"
+    input_name = "threshold_input_query"
+    operator   = "gt"
+    values     = [999999]
+  }
+
+  evaluation_interval {
+    interval    = "5m"
+    pending_for = "10m"
+  }
+
+  execution_error_state = "OK"
+  no_data_state         = "OK"
+
+  notification_settings {
+    method = "notificationRoutes"
+  }
 }
 `, name)
 }

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -44,6 +44,8 @@ const (
 	monitorV2DatasourceClickhouse = "clickhouse"
 
 	monitorV2QueryTypeInstant = "instant"
+
+	monitorV2DataTypeAnnotationKey = "_gc_data_type"
 )
 
 func NewMonitorV2Resource() resource.Resource {
@@ -218,7 +220,7 @@ func (r *monitorV2Resource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				ElementType:         types.StringType,
 			},
 			"annotations": schema.MapAttribute{
-				MarkdownDescription: fmt.Sprintf("Annotations to attach to the monitor and resulting alerts. The `%s` key is reserved for provider-managed Monitor V2 state and cannot be configured.", monitorV2QueryTypeAnnotationKey),
+				MarkdownDescription: fmt.Sprintf("Annotations to attach to the monitor and resulting alerts. The `%s` and `%s` keys are reserved for provider-managed Monitor V2 state and cannot be configured.", monitorV2QueryTypeAnnotationKey, monitorV2DataTypeAnnotationKey),
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
@@ -670,15 +672,17 @@ func monitorV2ValidateAnnotations(annotations types.Map, diags *diag.Diagnostics
 	if annotations.IsNull() || annotations.IsUnknown() {
 		return
 	}
-	if _, ok := annotations.Elements()[monitorV2QueryTypeAnnotationKey]; !ok {
-		return
-	}
 
-	diags.AddAttributeError(
-		path.Root("annotations").AtMapKey(monitorV2QueryTypeAnnotationKey),
-		"Reserved monitor annotation",
-		fmt.Sprintf("`annotations.%s` is reserved for provider-managed Monitor V2 state and cannot be configured.", monitorV2QueryTypeAnnotationKey),
-	)
+	for key := range annotations.Elements() {
+		if !monitorV2IsInternalAnnotation(key) {
+			continue
+		}
+		diags.AddAttributeError(
+			path.Root("annotations").AtMapKey(key),
+			"Reserved monitor annotation",
+			fmt.Sprintf("`annotations.%s` is reserved for provider-managed Monitor V2 state and cannot be configured.", key),
+		)
+	}
 }
 
 func monitorV2ValidateNotificationSettings(settings *monitorV2NotificationSettingsModel, diags *diag.Diagnostics) {
@@ -852,7 +856,7 @@ func buildMonitorV2CreateRequest(ctx context.Context, plan *monitorV2ResourceMod
 	var diags diag.Diagnostics
 	isProvisioned := true
 	req := &models.CreateMonitorRequest{
-		Annotations:          monitorV2AnnotationsToSDK(ctx, plan.Annotations, plan.Query, &diags),
+		Annotations:          monitorV2AnnotationsToSDK(ctx, plan.Annotations, &diags),
 		AutoResolve:          monitorV2Bool(plan.AutoResolve),
 		Category:             monitorV2String(plan.Category),
 		ExecutionErrorState:  monitorV2String(plan.ExecutionErrorState),
@@ -877,7 +881,7 @@ func buildMonitorV2CreateRequest(ctx context.Context, plan *monitorV2ResourceMod
 func buildMonitorV2UpdateRequest(ctx context.Context, plan *monitorV2ResourceModel) (*models.UpdateMonitorRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	req := &models.UpdateMonitorRequest{
-		Annotations:          monitorV2AnnotationsToSDK(ctx, plan.Annotations, plan.Query, &diags),
+		Annotations:          monitorV2AnnotationsToSDK(ctx, plan.Annotations, &diags),
 		AutoResolve:          monitorV2Bool(plan.AutoResolve),
 		Category:             monitorV2String(plan.Category),
 		ExecutionErrorState:  monitorV2String(plan.ExecutionErrorState),
@@ -1405,20 +1409,8 @@ func monitorV2StringMap(ctx context.Context, value types.Map, diags *diag.Diagno
 	return result
 }
 
-func monitorV2AnnotationsToSDK(ctx context.Context, annotations types.Map, query *monitorV2QueryModel, diags *diag.Diagnostics) map[string]string {
-	result := monitorV2StringMap(ctx, annotations, diags)
-	queryType := ""
-	if query != nil {
-		queryType = monitorV2String(query.Type)
-	}
-	if !monitorV2IsValidQueryType(queryType) {
-		return result
-	}
-	if result == nil {
-		result = make(map[string]string, 1)
-	}
-	result[monitorV2QueryTypeAnnotationKey] = queryType
-	return result
+func monitorV2AnnotationsToSDK(ctx context.Context, annotations types.Map, diags *diag.Diagnostics) map[string]string {
+	return monitorV2FilterAnnotations(monitorV2StringMap(ctx, annotations, diags))
 }
 
 func monitorV2StringList(ctx context.Context, value types.List, diags *diag.Diagnostics) []string {
@@ -1611,7 +1603,7 @@ func monitorV2FilterAnnotations(annotations map[string]string) map[string]string
 
 func monitorV2IsInternalAnnotation(key string) bool {
 	switch key {
-	case "_gc_data_type", monitorV2QueryTypeAnnotationKey:
+	case monitorV2DataTypeAnnotationKey, monitorV2QueryTypeAnnotationKey:
 		return true
 	default:
 		return false


### PR DESCRIPTION
# User description
## Summary
- stop `groundcover_monitor_v2` create/update requests from sending provider-internal annotations such as `_gc_monitor_v2_query_type`
- keep read-side compatibility for existing backend responses that still contain the query-type marker
- add unit coverage plus a focused import-then-update acceptance regression test
- add a changelog entry under the unreleased 1.14.1 section

## Root Cause
`groundcover_monitor_v2` used `_gc_monitor_v2_query_type` as a provider-managed annotation to preserve query-type classification, then sent that reserved key back on writes. The monitors API now rejects that key as internal, so importing a monitor and applying a follow-up update could fail with a 400 even when the HCL had no `annotations` block.

## Validation
- `PATH=/opt/homebrew/bin:$PATH GOFLAGS=-mod=mod go test ./internal/provider -run 'TestMonitorV2' -v`
- `PATH=/opt/homebrew/bin:$PATH TF_ACC=1 GOFLAGS=-mod=mod go test ./internal/provider -run TestAccMonitorV2Resource_importThenUpdate -v` with ephemeral backend credentials
- `PATH=/opt/homebrew/bin:$PATH GOFLAGS=-mod=mod go test ./internal/provider -v`
- `PATH=/opt/homebrew/bin:$PATH GOFLAGS=-mod=mod make generate`
- `PATH=/opt/homebrew/bin:$PATH GOFLAGS=-mod=mod make fmt`
- `git diff --check`

`make lint` could not run locally because the installed `golangci-lint` binary was built with Go 1.24 while this repo targets Go 1.25.9.

## PR checklist
- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Stop including provider-managed <code>_gc_monitor_v2_query_type</code> and <code>_gc_data_type</code> annotations in Monitor V2 create/update payloads while still mapping backend-provided markers during refresh so writes never send reserved keys. Document the reserved annotation restriction, extend annotation-filtering validation, and cover the flow with unit plus import-then-update acceptance tests plus a changelog entry.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/104?tool=ast&topic=Annotation+filtering>Annotation filtering</a>
        </td><td>Filter Monitor V2 annotations so create/update payloads remove <code>_gc_monitor_v2_query_type</code>/<code>_gc_data_type</code>, retain backend markers for reads, and update validation helpers and tests accordingly.<details><summary>Modified files (2)</summary><ul><li>internal/provider/resource_monitor_test.go</li>
<li>internal/provider/resource_monitor_v2.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>BE-2124 - fix monitor ...</td><td>June 14, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Merge branch 'main' in...</td><td>January 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/104?tool=ast&topic=Import+regression>Import regression</a>
        </td><td>Document reserved annotation handling, exercise the import-then-update flow, and log the fix in the changelog.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>docs/resources/monitor_v2.md</li>
<li>internal/provider/resource_monitor_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>BE-2124 - fix monitor ...</td><td>June 14, 2026</td></tr>
<tr><td>omer.karjevsky@groundc...</td><td>BE-1693 - Bump changel...</td><td>June 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/104?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `groundcover_monitor_v2` import and update operations failing due to internal annotation handling, ensuring provider-reserved annotation data is not sent back to the monitors API.

## Documentation
* Updated `groundcover_monitor_v2` annotation field documentation to clarify additional provider-reserved keys that cannot be configured by users.

## Tests
* Added/extended unit and acceptance coverage to verify reserved/internal annotation keys are removed on create/update and rejected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->