### PR TITLE
BE-2156: feat: support apm data type in monitor v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.0
+
+* Added `apm` as a supported GCQL `data_type` for `groundcover_monitor_v2`
+
 ## 1.14.1
 
 * Fixed `groundcover_monitor_v2` import/update failures caused by sending the reserved `_gc_monitor_v2_query_type` annotation back to the monitors API

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -234,6 +234,40 @@ resource "groundcover_monitor_v2" "gcql_issues" {
   no_data_state         = "OK"
 }
 
+resource "groundcover_monitor_v2" "gcql_apm" {
+  title            = "GCQL APM Count"
+  severity         = "warning"
+  measurement_type = "event"
+  is_paused        = true
+
+  display {
+    header      = "GCQL APM Count"
+    description = "Counts APM records returned by GCQL."
+  }
+
+  query {
+    type           = "gcql"
+    data_type      = "apm"
+    expression     = "* | stats count() count_all_result"
+    instant_rollup = "5m"
+  }
+
+  threshold {
+    name       = "threshold_1"
+    input_name = "threshold_input_query"
+    operator   = "gt"
+    values     = [1000]
+  }
+
+  evaluation_interval {
+    interval    = "1m"
+    pending_for = "1m"
+  }
+
+  execution_error_state = "OK"
+  no_data_state         = "OK"
+}
+
 resource "groundcover_monitor_v2" "metricsql" {
   title            = "MetricsQL Running Pods"
   severity         = "warning"
@@ -404,7 +438,7 @@ Required:
 
 Optional:
 
-- `data_type` (String) GCQL data type. Required when `type = "gcql"`. Supported values: `logs`, `traces`, `events`, `entities`, `rum`, `issues`.
+- `data_type` (String) GCQL data type. Required when `type = "gcql"`. Supported values: `logs`, `traces`, `events`, `entities`, `rum`, `issues`, `apm`.
 - `datasource_id` (String) Optional datasource identifier for raw queries.
 - `datasource_type` (String) Metrics datasource type for MetricsQL. Defaults to `prometheus` when `type = "metricsql"`.
 - `instant_rollup` (String) GCQL rollup window used to add the monitor evaluation time bucket, for example `5m` or `5 minutes`.

--- a/examples/resources/groundcover_monitor_v2/resource.tf
+++ b/examples/resources/groundcover_monitor_v2/resource.tf
@@ -219,6 +219,40 @@ resource "groundcover_monitor_v2" "gcql_issues" {
   no_data_state         = "OK"
 }
 
+resource "groundcover_monitor_v2" "gcql_apm" {
+  title            = "GCQL APM Count"
+  severity         = "warning"
+  measurement_type = "event"
+  is_paused        = true
+
+  display {
+    header      = "GCQL APM Count"
+    description = "Counts APM records returned by GCQL."
+  }
+
+  query {
+    type           = "gcql"
+    data_type      = "apm"
+    expression     = "* | stats count() count_all_result"
+    instant_rollup = "5m"
+  }
+
+  threshold {
+    name       = "threshold_1"
+    input_name = "threshold_input_query"
+    operator   = "gt"
+    values     = [1000]
+  }
+
+  evaluation_interval {
+    interval    = "1m"
+    pending_for = "1m"
+  }
+
+  execution_error_state = "OK"
+  no_data_state         = "OK"
+}
+
 resource "groundcover_monitor_v2" "metricsql" {
   title            = "MetricsQL Running Pods"
   severity         = "warning"

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -95,6 +95,29 @@ func TestMonitorV2BuildCreateRequestGCQL(t *testing.T) {
 	requireNoInternalMonitorV2Annotations(t, req.Annotations)
 }
 
+func TestMonitorV2BuildCreateRequestGCQLAPM(t *testing.T) {
+	ctx := context.Background()
+	plan := testMonitorV2BasePlan(t, &monitorV2QueryModel{
+		Type:          types.StringValue(monitorV2QueryTypeGCQL),
+		Expression:    types.StringValue(`* | stats count() count_all_result`),
+		DataType:      types.StringValue("apm"),
+		InstantRollup: types.StringValue("5 minutes"),
+	})
+
+	req, diags := buildMonitorV2CreateRequest(ctx, &plan)
+	if diags.HasError() {
+		t.Fatalf("buildMonitorV2CreateRequest() diagnostics: %v", diags)
+	}
+	query := req.Model.Queries[0]
+	if query.DataType != "apm" {
+		t.Fatalf("query.DataType = %q, want apm", query.DataType)
+	}
+	if query.InstantRollup != "5m" {
+		t.Fatalf("query.InstantRollup = %q, want 5m", query.InstantRollup)
+	}
+	requireNoInternalMonitorV2Annotations(t, req.Annotations)
+}
+
 func TestMonitorV2BuildCreateRequestMetricsQL(t *testing.T) {
 	ctx := context.Background()
 	plan := testMonitorV2BasePlan(t, &monitorV2QueryModel{
@@ -895,6 +918,9 @@ func TestAccMonitorV2Resource_allSupportedQueryTypes(t *testing.T) {
 					resource.TestCheckResourceAttrSet("groundcover_monitor_v2.issues", "id"),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.issues", "query.type", monitorV2QueryTypeGCQL),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.issues", "query.data_type", "issues"),
+					resource.TestCheckResourceAttrSet("groundcover_monitor_v2.apm", "id"),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.apm", "query.type", monitorV2QueryTypeGCQL),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.apm", "query.data_type", "apm"),
 					resource.TestCheckResourceAttrSet("groundcover_monitor_v2.metricsql", "id"),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.metricsql", "query.type", monitorV2QueryTypeMetricsQL),
 					resource.TestCheckResourceAttrSet("groundcover_monitor_v2.raw_sql", "id"),
@@ -1075,6 +1101,12 @@ func testAccMonitorV2AllSupportedQueryTypesConfig(suffix string) string {
 			resourceName:  "issues",
 			dataType:      "issues",
 			query:         "status:Alerting | stats count() count_all_result",
+			instantRollup: true,
+		},
+		{
+			resourceName:  "apm",
+			dataType:      "apm",
+			query:         "* | stats count() count_all_result",
 			instantRollup: true,
 		},
 	}

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -253,10 +253,10 @@ func (r *monitorV2Resource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:            true,
 					},
 					"data_type": schema.StringAttribute{
-						MarkdownDescription: "GCQL data type. Required when `type = \"gcql\"`. Supported values: `logs`, `traces`, `events`, `entities`, `rum`, `issues`.",
+						MarkdownDescription: "GCQL data type. Required when `type = \"gcql\"`. Supported values: `logs`, `traces`, `events`, `entities`, `rum`, `issues`, `apm`.",
 						Optional:            true,
 						Validators: []validator.String{
-							stringvalidator.OneOf("logs", "traces", "events", "entities", "rum", "issues"),
+							stringvalidator.OneOf("logs", "traces", "events", "entities", "rum", "issues", "apm"),
 						},
 					},
 					"datasource_type": schema.StringAttribute{


### PR DESCRIPTION
# User description
## Summary

Adds `apm` as a supported GCQL `data_type` for `groundcover_monitor_v2`.

## Changes

- Allows `query.data_type = "apm"` in the Monitor V2 schema validator and generated docs.
- Adds an APM GCQL monitor example.
- Adds focused unit coverage for APM request conversion and extends the opt-in all-supported-query-types acceptance config.
- Updates the changelog with the new supported data type.

Linear: https://linear.app/groundcover/issue/BE-2156/feat-support-apm-data-type-in-monitor-v2

## Verification

- `PATH="/opt/homebrew/bin:$PATH" GOFLAGS=-mod=mod make generate`
- `PATH="/opt/homebrew/bin:$PATH" GOFLAGS=-mod=mod go test ./internal/provider -run '^TestMonitorV2' -v`

## Checklist

- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable Monitor V2 schema, documentation, examples, and change log entries to accept <code>apm</code> as a GCQL <code>data_type</code> so Terraform plans and generated materials reflect the new option. Update request conversion tests and acceptance configs to cover GCQL APM so the provider ships focused verification for the added data type.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/105?tool=ast&topic=GCQL+APM+support>GCQL APM support</a>
        </td><td>Enable Monitor V2 schema validation, docs, examples, and changelog text to treat <code>apm</code> as a supported GCQL <code>data_type</code> so Terraform plans and generated guidance reflect the new option.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>docs/resources/monitor_v2.md</li>
<li>examples/resources/groundcover_monitor_v2/resource.tf</li>
<li>internal/provider/resource_monitor_v2.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>BE-2156 - support apm ...</td><td>June 16, 2026</td></tr>
<tr><td>omer.karjevsky@groundc...</td><td>BE-1693 - Bump changel...</td><td>June 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/105?tool=ast&topic=APM+query+tests>APM query tests</a>
        </td><td>Validate GCQL APM request conversion and acceptance coverage so query building emits the new data type and the opt-in suite exercises it.<details><summary>Modified files (1)</summary><ul><li>internal/provider/resource_monitor_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>BE-2156 - support apm ...</td><td>June 16, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Merge branch 'main' in...</td><td>January 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/105?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * APM monitoring is now available as a GCQL data_type option in groundcover_monitor_v2, allowing you to create monitors and configure alerts based on APM records.

* **Documentation**
  * Enhanced documentation with comprehensive examples showing how to set up groundcover_monitor_v2 monitors for APM data, including query configuration, threshold settings, evaluation intervals, and state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->