### PR TITLE
BE-2157: docs: include apm in monitor v2 reference

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -172,7 +172,7 @@ Manages a groundcover Monitor resource with a typed schema instead of raw YAML. 
 
 #### Example Usage
 
-The full example file includes GCQL examples for logs, traces, events, entities, RUM, and issues, plus MetricsQL and raw SQL examples.
+The full example file includes GCQL examples for logs, traces, events, entities, RUM, issues, and APM, plus MetricsQL and raw SQL examples.
 
 ```hcl
 resource "groundcover_monitor_v2" "gcql_logs" {

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -218,7 +218,7 @@ resource "groundcover_monitor_v2" "gcql_logs" {
 *   `title` (String, Required): Monitor title.
 *   `severity` (String, Required): Monitor severity.
 *   `measurement_type` (String, Required): `state` or `event`.
-*   `query` (Block, Required): Typed query definition. Supports `type = "gcql"`, `type = "metricsql"`, and `type = "raw_sql"`. GCQL supports `data_type` values `logs`, `traces`, `events`, `entities`, `rum`, and `issues`.
+*   `query` (Block, Required): Typed query definition. Supports `type = "gcql"`, `type = "metricsql"`, and `type = "raw_sql"`. GCQL supports `data_type` values `logs`, `traces`, `events`, `entities`, `rum`, `issues`, and `apm`.
 *   `threshold` (Block, Required): One or more threshold definitions. Supports optional `custom_resolve_threshold`.
 *   `notification_settings` (Block, Optional): Notification behavior, including `connected_app_params` for per-app Slack channels.
 *   `display`, `evaluation_interval`, `reducer`, `labels`, `annotations`, and `routing` are optional monitor settings.


### PR DESCRIPTION
# User description
## Summary

Updates `REFERENCE.md` so the `groundcover_monitor_v2` GCQL `data_type` supported-values line includes `apm`.

This is the docs-only follow-up to `BE-2156`, where the schema metadata, validator, generated resource docs, examples, and changelog were already updated.

Linear: https://linear.app/groundcover/issue/BE-2157/docs-include-apm-in-monitor-v2-reference

## Verification

- `git diff --check`

## Checklist

- [ ] I have written acceptance tests for my changes
- [ ] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [ ] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the REFERENCE documentation to include APM in the <code>groundcover_monitor_v2</code> GCQL <code>data_type</code> supported values and example overview. Clarify that the full example file now covers APM alongside other GCQL flows so the reference aligns with the schema and generated docs updates.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>avital@groundcover.com</td><td>BE-2157 - include apm ...</td><td>June 16, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/106?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GCQL `query` block documentation to include `data_type = "apm"` as a supported option, alongside existing options (logs, traces, events, entities, rum, issues).
  * Refreshed the typed-query example text to reflect inclusion of GCQL APM examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->