### PR TITLE
INF-2370: expose plugin-framework provider constructor for codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.16.0
 
 * Added `groundcover_connected_app_json` — a variant of `groundcover_connected_app` whose `data` is a JSON string (`jsonencode({...})`) instead of a dynamic object. Behaviour, drift detection (`data_hash`), and the underlying API are identical; the JSON-string form is for configs generated/consumed by tooling that can't model dynamic objects (e.g. the Crossplane provider). The existing `groundcover_connected_app` is unchanged.
+* Added `pkg/tfprovider`, a public re-export of the plugin-framework provider constructor (`internal/provider.New`), so the groundcover Crossplane provider can hand the live provider to upjet for schema introspection during code generation. No change to provider behaviour.
 
 ## 1.15.0
 

--- a/pkg/tfprovider/tfprovider.go
+++ b/pkg/tfprovider/tfprovider.go
@@ -1,0 +1,17 @@
+// Package tfprovider exposes the groundcover Terraform provider's plugin-framework
+// provider constructor outside of internal/, so the Crossplane code generator (a
+// separate Go module) can hand the provider to upjet for schema introspection during
+// generation.
+package tfprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	internalprovider "github.com/groundcover-com/terraform-provider-groundcover/internal/provider"
+)
+
+// New returns the plugin-framework provider constructor for the given version. It is a
+// thin re-export of internal/provider.New.
+func New(version string) func() provider.Provider {
+	return internalprovider.New(version)
+}


### PR DESCRIPTION
# User description
Adds `pkg/tfprovider`, a thin re-export of `internal/provider.New`, so the separate [crossplane-provider-groundcover](https://github.com/groundcover-com/crossplane-provider-groundcover) repo can hand the live plugin-framework provider to upjet for schema introspection during generation.

No behavior change to the Terraform provider — it only widens visibility of the existing constructor beyond `internal/`.

**Why:** the Crossplane provider's code generator builds its `config.Provider` from this provider's live PF schema (`config.WithTerraformPluginFrameworkProvider`). Go forbids importing `internal/` across modules, so the generator needs an exported entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Explain why the change introduced a public <code>pkg/tfprovider</code> module that re-exports the existing plugin-framework provider constructor so Crossplane’s code generator can build its <code>config.Provider</code> via <code>config.WithTerraformPluginFrameworkProvider</code>. Highlight that this surfaces the constructor used for schema introspection without altering the Terraform provider behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>note pkg/tfprovider in...</td><td>June 24, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>support apm monitor v2...</td><td>June 16, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/108?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public provider entry point for Terraform tooling, making provider construction available through the supported package path.
  * Added documentation for the latest release, including a note about the new provider access path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->