### PR TITLE
INF-2373: move pkg/tfprovider changelog entry to 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 1.16.1
+
+* Added `pkg/tfprovider`, a public re-export of the plugin-framework provider constructor (`internal/provider.New`), so the groundcover Crossplane provider can hand the live provider to upjet for schema introspection during code generation. No change to provider behaviour.
+
 ## 1.16.0
 
 * Added `groundcover_connected_app_json` — a variant of `groundcover_connected_app` whose `data` is a JSON string (`jsonencode({...})`) instead of a dynamic object. Behaviour, drift detection (`data_hash`), and the underlying API are identical; the JSON-string form is for configs generated/consumed by tooling that can't model dynamic objects (e.g. the Crossplane provider). The existing `groundcover_connected_app` is unchanged.
-* Added `pkg/tfprovider`, a public re-export of the plugin-framework provider constructor (`internal/provider.New`), so the groundcover Crossplane provider can hand the live provider to upjet for schema introspection during code generation. No change to provider behaviour.
 
 ## 1.15.0
 


### PR DESCRIPTION
# User description
`v1.16.0` is already tagged, but the `pkg/tfprovider` addition (PR #108) merged into `main` afterward. This moves its CHANGELOG bullet from 1.16.0 into a new **1.16.1** section so the changelog reflects the release it actually ships in.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new `1.16.1` changelog section.
  * Moved the `pkg/tfprovider` update to the correct release entry.
  * Kept the `groundcover_connected_app_json` note under `1.16.0` with minor ordering adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the release notes to add a 1.16.1 section that documents the <code>pkg/tfprovider</code> re-export so the Crossplane provider change reflects the correct shipping release. Clarify that the <code>groundcover_connected_app_json</code> note remains under 1.16.0 while the new entry sits in 1.16.1.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>move pkg/tfprovider ch...</td><td>June 24, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>support apm monitor v2...</td><td>June 16, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/109?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>