### PR TITLE
ci: cover TestAccMonitorV2JsonResource in release acceptance matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           - name: metrics-pipeline
             run_regex: '^TestAccMetricsPipelineResource.*$'
           - name: monitor
-            run_regex: '^(TestAccMonitorResource.*|TestAccMonitorV2Resource.*|TestAccCustomerApplyLoop_Monitor.*)$'
+            run_regex: '^(TestAccMonitorResource.*|TestAccMonitorV2Resource.*|TestAccMonitorV2JsonResource.*|TestAccCustomerApplyLoop_Monitor.*)$'
           - name: notification-route
             run_regex: '^TestAccNotificationRoute.*$'
           - name: rbac


### PR DESCRIPTION
# User description
## Summary

The `acceptance-test-coverage` check on the release workflow [failed](https://github.com/groundcover-com/terraform-provider-groundcover/actions/runs/28521682725/job/84547452064) because the new `TestAccMonitorV2JsonResource_basic` test — added alongside `groundcover_monitor_v2_json` in #111 — was not matched by any `run_regex` group in the release matrix. That check requires every `TestAcc*` test to belong to a group.

This adds `TestAccMonitorV2JsonResource.*` to the existing `monitor` group regex, alongside the other monitor tests.

## Checklist

- [ ] I have written acceptance tests for my changes (N/A — CI-only fix)
- [ ] I have run `make generate` to update generated docs (N/A)
- [ ] I have added examples demonstrating the new functionality (N/A)
- [ ] I have updated the README.md with details of changes (N/A)
- [ ] I have updated the CHANGELOG.md file (N/A — no user-facing provider change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded release validation to include additional monitor-related acceptance test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the release workflow’s acceptance-test-coverage matrix to include the monitor test group matching <code>TestAccMonitorV2JsonResource</code>. Ensure every <code>TestAcc*</code> test continues to map to a matrix entry so the coverage validation passes.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>ci: cover TestAccMonit...</td><td>July 01, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>feat: add typed monito...</td><td>June 08, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/112?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>