### PR TITLE
fix(synthetic_test): treat empty ID as not-found in Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.1
+
+* Fixed `groundcover_synthetic_test` reads with an empty ID: `GET /api/synthetics/v1/rules/{id}` with an empty id redirects (`301`) to the collection route and returns `200` with the full list — never a `404` — so `Read` mapped an ID-less list response into state and reported the resource as existing. `Read` now removes the resource from state when the ID is empty, and the SDK client returns not-found for an empty ID. This unblocks the groundcover Crossplane provider, whose pre-create existence check reads with an empty id and was otherwise stuck failing to derive the external-name (`cannot find id in tfstate`) and re-creating on every reconcile. No change to normal Terraform create/read/update/delete behaviour
+
 ## 1.17.0
 
 * Added `groundcover_monitor_v2_json` — a variant of `groundcover_monitor_v2` whose `notification_settings.connected_app_params` is a JSON string (`jsonencode({...})`) instead of an HCL nested map. Schema, behaviour, and the underlying API are otherwise identical; the JSON-string form is for configs generated/consumed by tooling that can't model nested maps (e.g. the Crossplane provider). The existing `groundcover_monitor_v2` is unchanged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.17.1
 
-* Fixed `groundcover_synthetic_test` reads with an empty ID: `GET /api/synthetics/v1/rules/{id}` with an empty id redirects (`301`) to the collection route and returns `200` with the full list — never a `404` — so `Read` mapped an ID-less list response into state and reported the resource as existing. `Read` now removes the resource from state when the ID is empty, and the SDK client returns not-found for an empty ID. This unblocks the groundcover Crossplane provider, whose pre-create existence check reads with an empty id and was otherwise stuck failing to derive the external-name (`cannot find id in tfstate`) and re-creating on every reconcile. No change to normal Terraform create/read/update/delete behaviour
+* Fixed `groundcover_synthetic_test` sending `GET /api/synthetics/v1/rules/{id}` with an empty ID — the provider now treats it as not-found instead of matching `GET /api/synthetics/v1/rules/` (which redirects to the list and returns 200)
 
 ## 1.17.0
 

--- a/internal/provider/client_syntheticstest.go
+++ b/internal/provider/client_syntheticstest.go
@@ -35,6 +35,13 @@ func (c *SdkClientWrapper) GetSyntheticTest(ctx context.Context, id string) (*mo
 	logFields := map[string]any{"req": "get_synthetic_test", "id": id}
 	tflog.Debug(ctx, "Executing SDK Call: Get Synthetic Test", logFields)
 
+	// An empty ID would otherwise be sent to GET /rules/{id}, which redirects to the
+	// collection route and returns 200 with the full list — never a 404. Treat it as
+	// not-found so callers don't mistake a list response for an existing resource.
+	if id == "" {
+		return nil, ErrNotFound
+	}
+
 	params := synthetics.NewGetSyntheticTestParamsWithContext(ctx).
 		WithTimeout(defaultTimeout).
 		WithID(id)

--- a/internal/provider/resource_syntheticstest.go
+++ b/internal/provider/resource_syntheticstest.go
@@ -820,6 +820,15 @@ func (r *syntheticTestResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	// An empty ID means the resource does not exist yet — e.g. a pre-create existence
+	// check by upjet/Crossplane. Without this guard, GetSyntheticTest("") hits the
+	// collection route (GET /rules/ -> 301 -> /rules -> 200) and returns an ID-less
+	// object, so the caller wrongly concludes the resource exists.
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	tflog.Debug(ctx, "Reading Synthetic Test resource", map[string]any{"id": state.ID.ValueString()})
 
 	sdkResp, err := r.client.GetSyntheticTest(ctx, state.ID.ValueString())

--- a/internal/provider/resource_syntheticstest_test.go
+++ b/internal/provider/resource_syntheticstest_test.go
@@ -4,6 +4,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -15,6 +16,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+// An empty ID must be treated as not-found before any HTTP call: GET /rules/{id}
+// with an empty id redirects to the collection route and returns the full list, which
+// callers (e.g. upjet's pre-create existence check) would misread as an existing
+// resource. The guard returns ErrNotFound without touching the SDK client, so a
+// nil-client wrapper is sufficient here.
+func TestGetSyntheticTestEmptyIDReturnsNotFound(t *testing.T) {
+	c := &SdkClientWrapper{}
+	resp, err := c.GetSyntheticTest(context.Background(), "")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for empty id, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response for empty id, got %v", resp)
+	}
+}
 
 func TestSyntheticTestFromSDKResponsePreservesEmptyHTTPHeaders(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
# User description
GetSyntheticTest("") builds a request to GET /api/synthetics/v1/rules/{id} with an empty id, which redirects (301) to the collection route and returns 200 with the full list — never a 404. So Read mapped an ID-less list response into state and reported the resource as existing.

This breaks upjet/Crossplane, whose pre-create existence check reads with an empty id: it sees resourceExists=true with no id, fails to derive the external-name ("cannot find id in tfstate"), and re-creates on every reconcile (leaking duplicate synthetic tests).

Guard both layers: Read removes the resource from state when the id is empty, and GetSyntheticTest returns ErrNotFound for an empty id so no other caller mistakes the list redirect for an existing resource. Add a unit test.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] I have written acceptance tests for my changes
- [ ] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [ ] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the provider’s synthetic test client and resource Read treat empty IDs as not-found so callers don’t mistake the list redirect for an existing synthetic test. Document the fix and cover the empty-id path with a unit test.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/113?tool=ast&topic=Empty+ID+flow>Empty ID flow</a>
        </td><td>Guard <code>GetSyntheticTest</code> and Read to return not-found when the synthetic test ID is blank so an empty request doesn’t impersonate an existing resource.<details><summary>Modified files (2)</summary><ul><li>internal/provider/client_syntheticstest.go</li>
<li>internal/provider/resource_syntheticstest.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>fix(synthetic_test): t...</td><td>July 07, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>fix synthetics asserti...</td><td>June 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/113?tool=ast&topic=Tests+%26+changelog>Tests &amp; changelog</a>
        </td><td>Document the behavior change and add a regression test that covers the empty-ID scenario.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>internal/provider/resource_syntheticstest_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>fix changelog</td><td>July 07, 2026</td></tr>
<tr><td>amir9339@gmail.com</td><td>feat: deprecate ground...</td><td>June 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/113?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty synthetic test IDs are now treated as not-found, avoiding “collection/list” style responses for individual-resource lookups.
  * Synthetic test read/refresh now removes the resource from state when an empty ID is provided, preventing incorrect existence checks.
* **Tests**
  * Added unit coverage to verify empty-ID requests return the expected not-found result without triggering SDK client calls.
* **Documentation**
  * Updated the changelog for version 1.17.1 describing the empty-ID not-found behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->