### PR TITLE
docs(monitor_v2_json): document connected_app_params Linear fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.1
+
+* Documented the `connected_app_params` Linear delivery options so they show up in the Crossplane provider
+
 ## 1.18.0
 
 * Added `groundcover_recurring_silence` — silences that repeat daily, weekly, or monthly, with per-day timeframes and a timezone

--- a/docs/resources/monitor_v2_json.md
+++ b/docs/resources/monitor_v2_json.md
@@ -112,7 +112,7 @@ Optional:
 
 Optional:
 
-- `connected_app_params` (String) JSON-encoded per-connected-app delivery options keyed by connected app ID. String form of `groundcover_monitor_v2.connected_app_params`, for schema code generators (Crossplane/upjet) that cannot represent nested maps. Each channel is an object with a required `id` and optional `name`. Example: `jsonencode({ "app-id" = { channels = [{ id = "C123", name = "#alerts" }] } })`.
+- `connected_app_params` (String) JSON-encoded per-connected-app delivery options keyed by connected app ID. String form of `groundcover_monitor_v2.connected_app_params`, for schema code generators (Crossplane/upjet) that cannot represent nested maps. Each entry is an object with: `channels` (list of `{ id (required), name }`) and the optional Linear fields `team_id`, `assignee_id`, `delegate_id`, `project_id`, `resolved_status_id`, `label_ids` (list of strings), and `auto_resolve` (bool). Example: `jsonencode({ "app-id" = { channels = [{ id = "C123", name = "#alerts" }], team_id = "T1", label_ids = ["L1"], auto_resolve = true } })`.
 - `connected_apps` (List of String) Connected app IDs to notify.
 - `disable_renotification` (Boolean) Whether renotification is disabled.
 - `method` (String) Notification method.

--- a/internal/provider/resource_monitor_v2_json.go
+++ b/internal/provider/resource_monitor_v2_json.go
@@ -113,7 +113,7 @@ func (r *monitorV2JsonResource) Schema(ctx context.Context, req resource.SchemaR
 
 	ns := s.Blocks["notification_settings"].(schema.SingleNestedBlock)
 	ns.Attributes["connected_app_params"] = schema.StringAttribute{
-		MarkdownDescription: "JSON-encoded per-connected-app delivery options keyed by connected app ID. String form of `groundcover_monitor_v2.connected_app_params`, for schema code generators (Crossplane/upjet) that cannot represent nested maps. Each channel is an object with a required `id` and optional `name`. Example: `jsonencode({ \"app-id\" = { channels = [{ id = \"C123\", name = \"#alerts\" }] } })`.",
+		MarkdownDescription: "JSON-encoded per-connected-app delivery options keyed by connected app ID. String form of `groundcover_monitor_v2.connected_app_params`, for schema code generators (Crossplane/upjet) that cannot represent nested maps. Each entry is an object with: `channels` (list of `{ id (required), name }`) and the optional Linear fields `team_id`, `assignee_id`, `delegate_id`, `project_id`, `resolved_status_id`, `label_ids` (list of strings), and `auto_resolve` (bool). Example: `jsonencode({ \"app-id\" = { channels = [{ id = \"C123\", name = \"#alerts\" }], team_id = \"T1\", label_ids = [\"L1\"], auto_resolve = true } })`.",
 		Optional:            true,
 	}
 	s.Blocks["notification_settings"] = ns


### PR DESCRIPTION
# User description
## What

The `connected_app_params` JSON string in `groundcover_monitor_v2_json` accepts per-app Linear delivery options — `team_id`, `assignee_id`, `delegate_id`, `project_id`, `resolved_status_id`, `label_ids`, `auto_resolve` — alongside `channels` (added in #114 / v1.18.0). But the field **description** still documented `channels` only.

This matters because the Crossplane/upjet provider is generated from this schema, and for `monitor_v2_json` the JSON-string field's **description is the only user-visible documentation** of the accepted shape (`kubectl explain`, generated CRD docs). So Crossplane users had no way to discover the Linear fields.

## Change

- Update the `connected_app_params` `MarkdownDescription` to document the full per-entry shape (`channels` + the 7 optional Linear fields) with an updated `jsonencode(...)` example.
- Sync the generated `docs/resources/monitor_v2_json.md`.

Description-only — no behavior change. The fields already work at runtime.

Tracked by BE-2479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the <code>connected_app_params</code> JSON schema in <code>monitor_v2_json</code> so the Linear delivery fields appear in the Crossplane/upjet provider and Crossplane users can discover the options. Sync the published resource docs and changelog so the generated documentation and release notes reflect the fuller description.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/118?tool=ast&topic=Release+notes>Release notes</a>
        </td><td>Add a 1.18.1 changelog entry noting the documented Linear delivery options so the release history highlights the Crossplane-facing update.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>chore: add 1.18.1 chan...</td><td>July 15, 2026</td></tr>
<tr><td>thehecticbyte@gmail.com</td><td>feat: add organization...</td><td>July 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/118?tool=ast&topic=Connected+App+doc>Connected App doc</a>
        </td><td>Document the <code>connected_app_params</code> field in <code>monitor_v2_json</code> and the generated monitor resource docs so each entry now lists <code>channels</code> plus the optional Linear fields with an updated example for Crossplane/upjet users.<details><summary>Modified files (2)</summary><ul><li>docs/resources/monitor_v2_json.md</li>
<li>internal/provider/resource_monitor_v2_json.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>docs(monitor_v2_json):...</td><td>July 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/118?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>