### PR TITLE
feat(monitor_v2): add query.evaluation_delay attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.19.0
+
+* Added `query.evaluation_delay` to `groundcover_monitor_v2` and `groundcover_monitor_v2_json` — an optional evaluation delay expressed as a duration from `0s` to `1h` (e.g. `15m`, `900s`; whole seconds only, the backend limit is 3600 seconds) that delays query evaluation to account for late-arriving data. Sent on create/update and read back during refresh and import
+
 ## 1.18.1
 
 * Documented the `connected_app_params` Linear delivery options so they show up in the Crossplane provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 1.19.0
 
 * Added `query.evaluation_delay` to `groundcover_monitor_v2` and `groundcover_monitor_v2_json` — an optional evaluation delay expressed as a duration from `0s` to `1h` (e.g. `15m`, `900s`; whole seconds only, the backend limit is 3600 seconds) that delays query evaluation to account for late-arriving data. Sent on create/update and read back during refresh and import
-
-## 1.18.1
-
 * Documented the `connected_app_params` Linear delivery options so they show up in the Crossplane provider
 
 ## 1.18.0

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -30,10 +30,11 @@ resource "groundcover_monitor_v2" "gcql_logs" {
   }
 
   query {
-    type           = "gcql"
-    data_type      = "logs"
-    expression     = "level:error | stats count() count_all_result"
-    instant_rollup = "5m"
+    type             = "gcql"
+    data_type        = "logs"
+    expression       = "level:error | stats count() count_all_result"
+    instant_rollup   = "5m"
+    evaluation_delay = "15m"
   }
 
   threshold {
@@ -359,6 +360,7 @@ Optional:
 - `data_type` (String) GCQL data type. Required when `type = "gcql"`. Supported values: `logs`, `traces`, `events`, `apm`.
 - `datasource_id` (String) Optional datasource identifier for raw queries.
 - `datasource_type` (String) Metrics datasource type for MetricsQL. Defaults to `prometheus` when `type = "metricsql"`.
+- `evaluation_delay` (String) Evaluation delay as a duration from `0s` to `1h`, whole seconds only, for example `15m` or `900s`. Delays query evaluation to account for late-arriving data.
 - `instant_rollup` (String) GCQL rollup window used to add the monitor evaluation time bucket, for example `5m` or `5 minutes`.
 - `name` (String) Query name. Defaults to `threshold_input_query`.
 - `query_type` (String) Query execution type for MetricsQL or raw SQL. Defaults to `instant`.

--- a/docs/resources/monitor_v2_json.md
+++ b/docs/resources/monitor_v2_json.md
@@ -24,10 +24,11 @@ resource "groundcover_monitor_v2_json" "gcql_logs" {
   measurement_type = "event"
 
   query {
-    type           = "gcql"
-    data_type      = "logs"
-    expression     = "level:error | stats count() count_all_result"
-    instant_rollup = "5m"
+    type             = "gcql"
+    data_type        = "logs"
+    expression       = "level:error | stats count() count_all_result"
+    instant_rollup   = "5m"
+    evaluation_delay = "15m"
   }
 
   threshold {
@@ -133,6 +134,7 @@ Optional:
 - `data_type` (String) GCQL data type. Required when `type = "gcql"`. Supported values: `logs`, `traces`, `events`, `apm`.
 - `datasource_id` (String) Optional datasource identifier for raw queries.
 - `datasource_type` (String) Metrics datasource type for MetricsQL. Defaults to `prometheus` when `type = "metricsql"`.
+- `evaluation_delay` (String) Evaluation delay as a duration from `0s` to `1h`, whole seconds only, for example `15m` or `900s`. Delays query evaluation to account for late-arriving data.
 - `instant_rollup` (String) GCQL rollup window used to add the monitor evaluation time bucket, for example `5m` or `5 minutes`.
 - `name` (String) Query name. Defaults to `threshold_input_query`.
 - `query_type` (String) Query execution type for MetricsQL or raw SQL. Defaults to `instant`.

--- a/examples/resources/groundcover_monitor_v2/resource.tf
+++ b/examples/resources/groundcover_monitor_v2/resource.tf
@@ -15,10 +15,11 @@ resource "groundcover_monitor_v2" "gcql_logs" {
   }
 
   query {
-    type           = "gcql"
-    data_type      = "logs"
-    expression     = "level:error | stats count() count_all_result"
-    instant_rollup = "5m"
+    type             = "gcql"
+    data_type        = "logs"
+    expression       = "level:error | stats count() count_all_result"
+    instant_rollup   = "5m"
+    evaluation_delay = "15m"
   }
 
   threshold {

--- a/examples/resources/groundcover_monitor_v2_json/resource.tf
+++ b/examples/resources/groundcover_monitor_v2_json/resource.tf
@@ -9,10 +9,11 @@ resource "groundcover_monitor_v2_json" "gcql_logs" {
   measurement_type = "event"
 
   query {
-    type           = "gcql"
-    data_type      = "logs"
-    expression     = "level:error | stats count() count_all_result"
-    instant_rollup = "5m"
+    type             = "gcql"
+    data_type        = "logs"
+    expression       = "level:error | stats count() count_all_result"
+    instant_rollup   = "5m"
+    evaluation_delay = "15m"
   }
 
   threshold {

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -63,10 +63,11 @@ measurementType: state`
 func TestMonitorV2BuildCreateRequestGCQL(t *testing.T) {
 	ctx := context.Background()
 	plan := testMonitorV2BasePlan(t, &monitorV2QueryModel{
-		Type:          types.StringValue(monitorV2QueryTypeGCQL),
-		Expression:    types.StringValue(`level:error | stats count() count_all_result`),
-		DataType:      types.StringValue("logs"),
-		InstantRollup: types.StringValue("5 minutes"),
+		Type:            types.StringValue(monitorV2QueryTypeGCQL),
+		Expression:      types.StringValue(`level:error | stats count() count_all_result`),
+		DataType:        types.StringValue("logs"),
+		InstantRollup:   types.StringValue("5 minutes"),
+		EvaluationDelay: types.StringValue("15m"),
 	})
 
 	req, diags := buildMonitorV2CreateRequest(ctx, &plan)
@@ -91,6 +92,9 @@ func TestMonitorV2BuildCreateRequestGCQL(t *testing.T) {
 	}
 	if query.InstantRollup != "5m" {
 		t.Fatalf("query.InstantRollup = %q, want 5m", query.InstantRollup)
+	}
+	if query.EvaluationDelay == nil || *query.EvaluationDelay != 900 {
+		t.Fatalf("query.EvaluationDelay = %v, want 900", query.EvaluationDelay)
 	}
 	requireNoInternalMonitorV2Annotations(t, req.Annotations)
 }
@@ -149,7 +153,49 @@ func TestMonitorV2BuildCreateRequestMetricsQL(t *testing.T) {
 	if time.Duration(query.Rollup.Time) != 5*time.Minute {
 		t.Fatalf("query.Rollup.Time = %s, want 5m", time.Duration(query.Rollup.Time))
 	}
+	if query.EvaluationDelay != nil {
+		t.Fatalf("query.EvaluationDelay = %v, want nil when unset", *query.EvaluationDelay)
+	}
 	requireNoInternalMonitorV2Annotations(t, req.Annotations)
+}
+
+func TestMonitorV2EvaluationDelayBounds(t *testing.T) {
+	cases := []struct {
+		input     string
+		wantOK    bool
+		wantValue int64
+	}{
+		{"0s", true, 0},
+		{"3600s", true, 3600},
+		{"1h", true, 3600},
+		{"15m", true, 900},
+		{"3601s", false, 0},
+		{"-1s", false, 0},
+		{"1500ms", false, 0},
+		{"not-a-duration", false, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			var diags diag.Diagnostics
+			got := monitorV2EvaluationDelayToSDK(types.StringValue(tc.input), &diags)
+			if tc.wantOK {
+				if diags.HasError() {
+					t.Fatalf("unexpected diagnostics for %q: %v", tc.input, diags)
+				}
+				if got == nil || *got != tc.wantValue {
+					t.Fatalf("evaluation_delay %q = %v, want %d", tc.input, got, tc.wantValue)
+				}
+				return
+			}
+			if !diags.HasError() {
+				t.Fatalf("expected error diagnostics for %q, got none", tc.input)
+			}
+			if got != nil {
+				t.Fatalf("expected nil result for invalid %q, got %d", tc.input, *got)
+			}
+		})
+	}
 }
 
 func TestMonitorV2BuildCreateRequestRawSQL(t *testing.T) {
@@ -889,6 +935,7 @@ func TestAccMonitorV2Resource(t *testing.T) {
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "query.type", monitorV2QueryTypeGCQL),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "query.data_type", "logs"),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "query.instant_rollup", "5m"),
+					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "query.evaluation_delay", "15m"),
 					resource.TestCheckResourceAttr("groundcover_monitor_v2.test", "threshold.#", "1"),
 				),
 			},
@@ -1046,10 +1093,11 @@ resource "groundcover_monitor_v2" "test" {
   }
 
   query {
-    type           = "gcql"
-    data_type      = "logs"
-    expression     = "level:error | stats count() count_all_result"
-    instant_rollup = "5m"
+    type             = "gcql"
+    data_type        = "logs"
+    expression       = "level:error | stats count() count_all_result"
+    instant_rollup   = "5m"
+    evaluation_delay = "15m"
   }
 
   threshold {

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -87,6 +87,7 @@ type monitorV2QueryModel struct {
 	DatasourceID      types.String                 `tfsdk:"datasource_id"`
 	QueryType         types.String                 `tfsdk:"query_type"`
 	InstantRollup     types.String                 `tfsdk:"instant_rollup"`
+	EvaluationDelay   types.String                 `tfsdk:"evaluation_delay"`
 	Rollup            *monitorV2RollupModel        `tfsdk:"rollup"`
 	RelativeTimerange *monitorV2RelativeRangeModel `tfsdk:"relative_timerange"`
 }
@@ -293,6 +294,11 @@ func (r *monitorV2Resource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					},
 					"instant_rollup": schema.StringAttribute{
 						MarkdownDescription: "GCQL rollup window used to add the monitor evaluation time bucket, for example `5m` or `5 minutes`.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"evaluation_delay": schema.StringAttribute{
+						MarkdownDescription: "Evaluation delay as a duration from `0s` to `1h`, whole seconds only, for example `15m` or `900s`. Delays query evaluation to account for late-arriving data.",
 						Optional:            true,
 						Computed:            true,
 					},
@@ -643,6 +649,9 @@ func validateMonitorV2Config(ctx context.Context, config *monitorV2ResourceModel
 			)
 		}
 	}
+
+	// Surface evaluation_delay parse/range errors at plan time; the result is discarded here.
+	monitorV2EvaluationDelayToSDK(config.Query.EvaluationDelay, diags)
 
 	if len(config.Thresholds) == 0 {
 		diags.AddAttributeError(
@@ -997,6 +1006,7 @@ func monitorV2QueryToSDK(query *monitorV2QueryModel, diags *diag.Diagnostics) *m
 		Name:              name,
 		Expression:        monitorV2String(query.Expression),
 		DatasourceID:      monitorV2String(query.DatasourceID),
+		EvaluationDelay:   monitorV2EvaluationDelayToSDK(query.EvaluationDelay, diags),
 		RelativeTimerange: monitorV2RelativeRangeToSDK(query.RelativeTimerange, diags),
 	}
 
@@ -1185,6 +1195,7 @@ func monitorV2PreserveQueryDurations(previous, updated *monitorV2QueryModel) *mo
 	}
 
 	updated.InstantRollup = monitorV2PreserveDurationString(previous.InstantRollup, updated.InstantRollup)
+	updated.EvaluationDelay = monitorV2PreserveDurationString(previous.EvaluationDelay, updated.EvaluationDelay)
 	updated.RelativeTimerange = monitorV2PreserveRelativeRangeDurations(previous.RelativeTimerange, updated.RelativeTimerange)
 	if previous.Rollup != nil && updated.Rollup != nil {
 		updated.Rollup.Time = monitorV2PreserveDurationString(previous.Rollup.Time, updated.Rollup.Time)
@@ -1267,6 +1278,7 @@ func monitorV2QueryFromSDK(query *models.BaseQuery, annotations map[string]strin
 		DatasourceID:      monitorV2NullableString(query.DatasourceID),
 		QueryType:         monitorV2NullableString(query.QueryType),
 		InstantRollup:     monitorV2DurationStringToType(query.InstantRollup),
+		EvaluationDelay:   monitorV2EvaluationDelayFromSDK(query.EvaluationDelay),
 		Rollup:            monitorV2RollupFromSDK(query.Rollup),
 		RelativeTimerange: monitorV2RelativeRangeFromSDK(query.RelativeTimerange),
 	}
@@ -1426,6 +1438,34 @@ func monitorV2StringPtr(value types.String) *string {
 		return nil
 	}
 	return &str
+}
+
+// monitorV2EvaluationDelayToSDK parses the duration string into the backend's whole-second int64 (0..3600).
+func monitorV2EvaluationDelayToSDK(value types.String, diags *diag.Diagnostics) *int64 {
+	attrPath := path.Root("query").AtName("evaluation_delay")
+	parsed, ok := monitorV2ParseDuration(value, attrPath, diags)
+	if !ok {
+		return nil
+	}
+	if parsed%time.Second != 0 {
+		diags.AddAttributeError(attrPath, "Invalid evaluation delay",
+			fmt.Sprintf("`query.evaluation_delay` must be a whole number of seconds; got %q.", value.ValueString()))
+		return nil
+	}
+	if parsed < 0 || parsed > time.Hour {
+		diags.AddAttributeError(attrPath, "Invalid evaluation delay",
+			fmt.Sprintf("`query.evaluation_delay` must be between `0s` and `1h` (3600 seconds); got %q.", value.ValueString()))
+		return nil
+	}
+	seconds := int64(parsed / time.Second)
+	return &seconds
+}
+
+func monitorV2EvaluationDelayFromSDK(value *int64) types.String {
+	if value == nil {
+		return types.StringNull()
+	}
+	return monitorV2DurationToType(time.Duration(*value) * time.Second)
 }
 
 func monitorV2StringPtrToType(value *string) types.String {


### PR DESCRIPTION
# User description
## Summary

Implements [INF-2654](https://linear.app/groundcover/issue/INF-2654). Adds support for monitor evaluation delay to `groundcover_monitor_v2` by exposing the backend `model.queries[0].evaluationDelay` field as a new `query.evaluation_delay` attribute.

- Optional integer, whole seconds, validated to the backend-supported range `0..3600` via a framework validator.
- Sent on create/update and read back on read/import (exact int, so no perpetual diffs).
- `groundcover_monitor_v2_json` gets it for free via the shared query model and reused schema.

## Changes

- `internal/provider/resource_monitor_v2.go` — `EvaluationDelay types.Int64` on `monitorV2QueryModel`, `evaluation_delay` schema attribute with `int64validator.Between(0, 3600)`, mapping to/from `models.BaseQuery.EvaluationDelay` (`*int64`).
- `internal/provider/resource_monitor_test.go` — unit assertions that the GCQL builder sends `900` and MetricsQL (unset) sends `nil`; acceptance config + round-trip check.
- Docs, example, and CHANGELOG updated (docs edited by hand — `terraform`/`tfplugindocs` not available locally).

## Testing

`go vet` clean, all 257 provider unit tests pass. Acceptance tests require a live backend.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose query evaluation delay in the monitor V2 resource schema and SDK mapping so the Terraform attribute round-trips <code>EvaluationDelay</code> while staying optional. Document and test the new attribute across acceptance/unit suites, examples, and release notes to capture validation, usage, and changelog details.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/119?tool=ast&topic=Evaluation+delay>Evaluation delay</a>
        </td><td>Expose <code>query.evaluation_delay</code> through the monitor V2 query schema, validators, and SDK conversion helpers so the backend <code>evaluationDelay</code> is sent, read, and preserved during updates without forcing the attribute.<details><summary>Modified files (1)</summary><ul><li>internal/provider/resource_monitor_v2.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guy.tabak@groundcover.com</td><td>feat(monitor_v2): add ...</td><td>July 16, 2026</td></tr>
<tr><td>nir.sagi@groundcover.com</td><td>Nirsagi/be 2442 terraf...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/119?tool=ast&topic=Docs+%26+tests>Docs &amp; tests</a>
        </td><td>Extend tests, examples, docs, and the changelog to cover valid evaluation delays, usage examples, and release notes for the new attribute.<details><summary>Modified files (6)</summary><ul><li>CHANGELOG.md</li>
<li>docs/resources/monitor_v2.md</li>
<li>docs/resources/monitor_v2_json.md</li>
<li>examples/resources/groundcover_monitor_v2/resource.tf</li>
<li>examples/resources/groundcover_monitor_v2_json/resource.tf</li>
<li>internal/provider/resource_monitor_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guy.tabak@groundcover.com</td><td>chore: fold unreleased...</td><td>July 16, 2026</td></tr>
<tr><td>nir.sagi@groundcover.com</td><td>docs(monitor_v2_json):...</td><td>July 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/119?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>