### PR TITLE
INF-2781 - Add connected app params support to notification routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.20.0
+
+* Added `params` to `groundcover_notification_route` route connected apps — optional per-app delivery parameters: `channels` (list of `{ id, name }` Slack channel objects) for `slack-app` routes, and the Linear fields `team_id`, `assignee_id`, `delegate_id`, `project_id`, `resolved_status_id`, `label_ids`, and `auto_resolve`. Previously connected apps only accepted `id` and `type`, so `slack-app` and `linear` notification routes could not be managed with Terraform
+
 ## 1.19.0
 
 * Added `query.evaluation_delay` to `groundcover_monitor_v2` and `groundcover_monitor_v2_json` — an optional evaluation delay expressed as a duration from `0s` to `1h` (e.g. `15m`, `900s`; whole seconds only, the backend limit is 3600 seconds) that delays query evaluation to account for late-arriving data. Sent on create/update and read back during refresh and import

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Basic usage examples can be found in the `examples/` directory:
 *   **Connected App (JSON) Resource:** [`examples/resources/groundcover_connected_app_json/resource.tf`](./examples/resources/groundcover_connected_app_json/resource.tf)
     *   Same as Connected App, but `data` is a JSON string — for generated configs or tooling that can't model dynamic objects (e.g. Crossplane).
 *   **Notification Route Resource:** [`examples/resources/groundcover_notification_route/resource.tf`](./examples/resources/groundcover_notification_route/resource.tf)
-    *   Demonstrates how to create and manage notification routes for routing alerts to connected apps.
+    *   Demonstrates how to create and manage notification routes for routing alerts to connected apps, including per-app delivery `params` (Slack channels for `slack-app`, Linear team/project/label options).
 *   **Secret Resource:** [`examples/resources/groundcover_secret/resource.tf`](./examples/resources/groundcover_secret/resource.tf)
     *   Demonstrates how to securely store sensitive values and receive reference IDs for use in other resources.
 *   **Synthetic Test Resource:** [`examples/resources/groundcover_synthetic_test/resource.tf`](./examples/resources/groundcover_synthetic_test/resource.tf)

--- a/docs/resources/notification_route.md
+++ b/docs/resources/notification_route.md
@@ -120,6 +120,57 @@ resource "groundcover_notification_route" "all_alerts_to_slack" {
   }
 }
 
+# slack-app and linear connected apps are installed through the groundcover UI
+# (OAuth flow), so they are referenced by ID rather than created in Terraform.
+variable "slack_app_id" {
+  type        = string
+  description = "ID of an existing slack-app connected app"
+}
+
+variable "linear_app_id" {
+  type        = string
+  description = "ID of an existing linear connected app"
+}
+
+resource "groundcover_notification_route" "slack_app_and_linear" {
+  name  = "critical-alerts-slack-app-linear"
+  query = "severity:critical"
+
+  routes = [
+    {
+      status = ["Alerting", "Resolved"]
+      connected_apps = [
+        {
+          # slack-app routes require params.channels
+          type = "slack-app"
+          id   = var.slack_app_id
+          params = {
+            channels = [
+              {
+                id   = "C0123456789"
+                name = "#alerts"
+              }
+            ]
+          }
+        },
+        {
+          # linear routes require params.team_id, and resolved_status_id
+          # unless auto_resolve is set to false
+          type = "linear"
+          id   = var.linear_app_id
+          params = {
+            team_id            = "d1b2c3d4-team"
+            project_id         = "d1b2c3d4-project"
+            label_ids          = ["d1b2c3d4-label"]
+            resolved_status_id = "d1b2c3d4-status"
+            auto_resolve       = true
+          }
+        }
+      ]
+    }
+  ]
+}
+
 output "critical_route_id" {
   description = "ID of the critical alerts notification route"
   value       = groundcover_notification_route.critical_alerts.id
@@ -166,7 +217,38 @@ Required:
 Required:
 
 - `id` (String) ID of the connected app.
-- `type` (String) Type of connected app (e.g., 'slack-webhook', 'pagerduty').
+- `type` (String) Type of connected app (e.g., 'slack-webhook', 'slack-app', 'pagerduty', 'linear').
+
+Optional:
+
+- `params` (Attributes) Route-specific delivery parameters for this connected app. 'slack-app' routes require channels; Linear routes use team_id and the related Linear fields. Omit for connected app types that don't support route params. (see [below for nested schema](#nestedatt--routes--connected_apps--params))
+
+<a id="nestedatt--routes--connected_apps--params"></a>
+### Nested Schema for `routes.connected_apps.params`
+
+Optional:
+
+- `assignee_id` (String) Linear user to assign created/updated issues to.
+- `auto_resolve` (Boolean) Whether resolved issues transition the linked Linear issues. The backend defaults this to true when unset.
+- `channels` (Attributes List) Slack channels to notify for this connected app. Required for 'slack-app' routes. (see [below for nested schema](#nestedatt--routes--connected_apps--params--channels))
+- `delegate_id` (String) Linear agent to delegate created/updated issues to.
+- `label_ids` (List of String) Linear label IDs to assign to created/updated issues.
+- `project_id` (String) Linear project to assign created/updated issues to.
+- `resolved_status_id` (String) Linear status used when auto-resolving issues. Required when auto_resolve is true or unset.
+- `team_id` (String) Linear team that receives created issues.
+
+<a id="nestedatt--routes--connected_apps--params--channels"></a>
+### Nested Schema for `routes.connected_apps.params.channels`
+
+Required:
+
+- `id` (String) Slack channel ID used for delivery.
+
+Optional:
+
+- `name` (String) Channel display name shown by channel selectors; optional.
+
+
 
 
 

--- a/examples/resources/groundcover_notification_route/resource.tf
+++ b/examples/resources/groundcover_notification_route/resource.tf
@@ -105,6 +105,57 @@ resource "groundcover_notification_route" "all_alerts_to_slack" {
   }
 }
 
+# slack-app and linear connected apps are installed through the groundcover UI
+# (OAuth flow), so they are referenced by ID rather than created in Terraform.
+variable "slack_app_id" {
+  type        = string
+  description = "ID of an existing slack-app connected app"
+}
+
+variable "linear_app_id" {
+  type        = string
+  description = "ID of an existing linear connected app"
+}
+
+resource "groundcover_notification_route" "slack_app_and_linear" {
+  name  = "critical-alerts-slack-app-linear"
+  query = "severity:critical"
+
+  routes = [
+    {
+      status = ["Alerting", "Resolved"]
+      connected_apps = [
+        {
+          # slack-app routes require params.channels
+          type = "slack-app"
+          id   = var.slack_app_id
+          params = {
+            channels = [
+              {
+                id   = "C0123456789"
+                name = "#alerts"
+              }
+            ]
+          }
+        },
+        {
+          # linear routes require params.team_id, and resolved_status_id
+          # unless auto_resolve is set to false
+          type = "linear"
+          id   = var.linear_app_id
+          params = {
+            team_id            = "d1b2c3d4-team"
+            project_id         = "d1b2c3d4-project"
+            label_ids          = ["d1b2c3d4-label"]
+            resolved_status_id = "d1b2c3d4-status"
+            auto_resolve       = true
+          }
+        }
+      ]
+    }
+  ]
+}
+
 output "critical_route_id" {
   description = "ID of the critical alerts notification route"
   value       = groundcover_notification_route.critical_alerts.id

--- a/internal/provider/resource_notification_route.go
+++ b/internal/provider/resource_notification_route.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -143,19 +146,31 @@ func (r *notificationRouteResource) Schema(_ context.Context, _ resource.SchemaR
 									"params": schema.SingleNestedAttribute{
 										Description: "Route-specific delivery parameters for this connected app. 'slack-app' routes require channels; Linear routes use team_id and the related Linear fields. Omit for connected app types that don't support route params.",
 										Optional:    true,
+										Validators: []validator.Object{
+											routeParamsNotEmptyValidator{},
+										},
 										Attributes: map[string]schema.Attribute{
 											"channels": schema.ListNestedAttribute{
 												Description: "Slack channels to notify for this connected app. Required for 'slack-app' routes.",
 												Optional:    true,
+												Validators: []validator.List{
+													listvalidator.SizeAtLeast(1),
+												},
 												NestedObject: schema.NestedAttributeObject{
 													Attributes: map[string]schema.Attribute{
 														"id": schema.StringAttribute{
 															Description: "Slack channel ID used for delivery.",
 															Required:    true,
+															Validators: []validator.String{
+																stringvalidator.LengthAtLeast(1),
+															},
 														},
 														"name": schema.StringAttribute{
 															Description: "Channel display name shown by channel selectors; optional.",
 															Optional:    true,
+															Validators: []validator.String{
+																stringvalidator.LengthAtLeast(1),
+															},
 														},
 													},
 												},
@@ -163,27 +178,45 @@ func (r *notificationRouteResource) Schema(_ context.Context, _ resource.SchemaR
 											"team_id": schema.StringAttribute{
 												Description: "Linear team that receives created issues.",
 												Optional:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"assignee_id": schema.StringAttribute{
 												Description: "Linear user to assign created/updated issues to.",
 												Optional:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"delegate_id": schema.StringAttribute{
 												Description: "Linear agent to delegate created/updated issues to.",
 												Optional:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"project_id": schema.StringAttribute{
 												Description: "Linear project to assign created/updated issues to.",
 												Optional:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"resolved_status_id": schema.StringAttribute{
 												Description: "Linear status used when auto-resolving issues. Required when auto_resolve is true or unset.",
 												Optional:    true,
+												Validators: []validator.String{
+													stringvalidator.LengthAtLeast(1),
+												},
 											},
 											"label_ids": schema.ListAttribute{
 												Description: "Linear label IDs to assign to created/updated issues.",
 												Optional:    true,
 												ElementType: types.StringType,
+												Validators: []validator.List{
+													listvalidator.SizeAtLeast(1),
+												},
 											},
 											"auto_resolve": schema.BoolAttribute{
 												Description: "Whether resolved issues transition the linked Linear issues. The backend defaults this to true when unset.",
@@ -757,6 +790,39 @@ func preserveEquivalentDuration(ctx context.Context, original, updated types.Obj
 	}
 
 	return updated
+}
+
+// routeParamsNotEmptyValidator rejects a params object whose attributes are
+// all null. routeConnectedAppParamsToSDK omits unset attributes from the API
+// request, so an all-null params object would be sent as absent, read back as
+// null, and no longer match the known non-null object in the plan — which
+// Terraform reports as an inconsistent result after apply. Rejecting it at
+// validation time keeps every accepted config round-trippable.
+type routeParamsNotEmptyValidator struct{}
+
+func (routeParamsNotEmptyValidator) Description(context.Context) string {
+	return "params must set at least one attribute"
+}
+
+func (v routeParamsNotEmptyValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (routeParamsNotEmptyValidator) ValidateObject(_ context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	for _, value := range req.ConfigValue.Attributes() {
+		// An unknown value may resolve to a real value at apply time.
+		if !value.IsNull() {
+			return
+		}
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Empty connected app params",
+		"params must set at least one attribute when specified; omit params entirely for connected app types that don't support route parameters.",
+	)
 }
 
 // routeConnectedAppParamsToSDK converts the typed params object into the

--- a/internal/provider/resource_notification_route.go
+++ b/internal/provider/resource_notification_route.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -55,8 +56,38 @@ type routeRuleModel struct {
 }
 
 type routeConnectedAppModel struct {
-	Type types.String `tfsdk:"type"`
-	Id   types.String `tfsdk:"id"`
+	Type   types.String `tfsdk:"type"`
+	Id     types.String `tfsdk:"id"`
+	Params types.Object `tfsdk:"params"`
+}
+
+type routeConnectedAppParamsModel struct {
+	Channels         types.List   `tfsdk:"channels"`
+	TeamID           types.String `tfsdk:"team_id"`
+	AssigneeID       types.String `tfsdk:"assignee_id"`
+	DelegateID       types.String `tfsdk:"delegate_id"`
+	ProjectID        types.String `tfsdk:"project_id"`
+	ResolvedStatusID types.String `tfsdk:"resolved_status_id"`
+	LabelIDs         types.List   `tfsdk:"label_ids"`
+	AutoResolve      types.Bool   `tfsdk:"auto_resolve"`
+}
+
+type routeConnectedAppChannelModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+// routeConnectedAppParamsWire mirrors the JSON shape the API uses inside
+// RouteConnectedApp{Request,Response}.Params (see models.ConnectedAppDeliveryOptions).
+type routeConnectedAppParamsWire struct {
+	Channels         []*models.ConnectedAppChannel `json:"channels"`
+	TeamID           string                        `json:"team_id"`
+	AssigneeID       string                        `json:"assignee_id"`
+	DelegateID       string                        `json:"delegate_id"`
+	ProjectID        string                        `json:"project_id"`
+	ResolvedStatusID string                        `json:"resolved_status_id"`
+	LabelIDs         []string                      `json:"label_ids"`
+	AutoResolve      *bool                         `json:"auto_resolve"`
 }
 
 type notificationSettingsModel struct {
@@ -102,12 +133,64 @@ func (r *notificationRouteResource) Schema(_ context.Context, _ resource.SchemaR
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"type": schema.StringAttribute{
-										Description: "Type of connected app (e.g., 'slack-webhook', 'pagerduty').",
+										Description: "Type of connected app (e.g., 'slack-webhook', 'slack-app', 'pagerduty', 'linear').",
 										Required:    true,
 									},
 									"id": schema.StringAttribute{
 										Description: "ID of the connected app.",
 										Required:    true,
+									},
+									"params": schema.SingleNestedAttribute{
+										Description: "Route-specific delivery parameters for this connected app. 'slack-app' routes require channels; Linear routes use team_id and the related Linear fields. Omit for connected app types that don't support route params.",
+										Optional:    true,
+										Attributes: map[string]schema.Attribute{
+											"channels": schema.ListNestedAttribute{
+												Description: "Slack channels to notify for this connected app. Required for 'slack-app' routes.",
+												Optional:    true,
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"id": schema.StringAttribute{
+															Description: "Slack channel ID used for delivery.",
+															Required:    true,
+														},
+														"name": schema.StringAttribute{
+															Description: "Channel display name shown by channel selectors; optional.",
+															Optional:    true,
+														},
+													},
+												},
+											},
+											"team_id": schema.StringAttribute{
+												Description: "Linear team that receives created issues.",
+												Optional:    true,
+											},
+											"assignee_id": schema.StringAttribute{
+												Description: "Linear user to assign created/updated issues to.",
+												Optional:    true,
+											},
+											"delegate_id": schema.StringAttribute{
+												Description: "Linear agent to delegate created/updated issues to.",
+												Optional:    true,
+											},
+											"project_id": schema.StringAttribute{
+												Description: "Linear project to assign created/updated issues to.",
+												Optional:    true,
+											},
+											"resolved_status_id": schema.StringAttribute{
+												Description: "Linear status used when auto-resolving issues. Required when auto_resolve is true or unset.",
+												Optional:    true,
+											},
+											"label_ids": schema.ListAttribute{
+												Description: "Linear label IDs to assign to created/updated issues.",
+												Optional:    true,
+												ElementType: types.StringType,
+											},
+											"auto_resolve": schema.BoolAttribute{
+												Description: "Whether resolved issues transition the linked Linear issues. The backend defaults this to true when unset.",
+												Optional:    true,
+												Computed:    true,
+											},
+										},
 									},
 								},
 							},
@@ -429,9 +512,17 @@ func routesListToSDK(ctx context.Context, routesList types.List) ([]*models.Rout
 		for j, appModel := range connectedAppModels {
 			typeStr := appModel.Type.ValueString()
 			idStr := appModel.Id.ValueString()
+
+			params, paramsDiags := routeConnectedAppParamsToSDK(ctx, appModel.Params)
+			diags.Append(paramsDiags...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
 			sdkConnectedApps[j] = &models.RouteConnectedAppRequest{
-				Type: &typeStr,
-				ID:   &idStr,
+				Type:   &typeStr,
+				ID:     &idStr,
+				Params: params,
 			}
 		}
 
@@ -467,11 +558,18 @@ func routesSDKToList(ctx context.Context, sdkRoutes []*models.RouteRuleResponse)
 		// Convert connected apps list
 		connectedAppElements := make([]attr.Value, len(sdkRoute.ConnectedApps))
 		for j, sdkApp := range sdkRoute.ConnectedApps {
+			paramsObj, paramsDiags := routeConnectedAppParamsToObject(ctx, sdkApp.Params)
+			diags.Append(paramsDiags...)
+			if diags.HasError() {
+				return types.ListNull(types.ObjectType{AttrTypes: routeRuleAttrTypes()}), diags
+			}
+
 			appObj, appDiags := types.ObjectValue(
 				routeConnectedAppAttrTypes(),
 				map[string]attr.Value{
-					"type": types.StringValue(sdkApp.Type),
-					"id":   types.StringValue(sdkApp.ID),
+					"type":   types.StringValue(sdkApp.Type),
+					"id":     types.StringValue(sdkApp.ID),
+					"params": paramsObj,
 				},
 			)
 			diags.Append(appDiags...)
@@ -661,12 +759,184 @@ func preserveEquivalentDuration(ctx context.Context, original, updated types.Obj
 	return updated
 }
 
+// routeConnectedAppParamsToSDK converts the typed params object into the
+// map[string]any the API expects in RouteConnectedAppRequest.Params. Only
+// attributes that are actually set are included, so connected app types that
+// don't support route params (or don't use a given field) never receive it.
+// An explicitly set auto_resolve is always sent — including false, which must
+// not be dropped because the backend defaults auto_resolve to true when unset.
+func routeConnectedAppParamsToSDK(ctx context.Context, params types.Object) (map[string]any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if params.IsNull() || params.IsUnknown() {
+		return nil, diags
+	}
+
+	var model routeConnectedAppParamsModel
+	diags.Append(params.As(ctx, &model, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	result := map[string]any{}
+
+	if !model.Channels.IsNull() && !model.Channels.IsUnknown() {
+		var channelModels []routeConnectedAppChannelModel
+		diags.Append(model.Channels.ElementsAs(ctx, &channelModels, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		channels := make([]*models.ConnectedAppChannel, 0, len(channelModels))
+		for _, ch := range channelModels {
+			id := ch.ID.ValueString()
+			channels = append(channels, &models.ConnectedAppChannel{
+				ID:   &id,
+				Name: ch.Name.ValueString(),
+			})
+		}
+		if len(channels) > 0 {
+			result["channels"] = channels
+		}
+	}
+
+	setRouteParamString(result, "team_id", model.TeamID)
+	setRouteParamString(result, "assignee_id", model.AssigneeID)
+	setRouteParamString(result, "delegate_id", model.DelegateID)
+	setRouteParamString(result, "project_id", model.ProjectID)
+	setRouteParamString(result, "resolved_status_id", model.ResolvedStatusID)
+
+	if !model.LabelIDs.IsNull() && !model.LabelIDs.IsUnknown() {
+		var labelIDs []string
+		diags.Append(model.LabelIDs.ElementsAs(ctx, &labelIDs, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if len(labelIDs) > 0 {
+			result["label_ids"] = labelIDs
+		}
+	}
+
+	if !model.AutoResolve.IsNull() && !model.AutoResolve.IsUnknown() {
+		result["auto_resolve"] = model.AutoResolve.ValueBool()
+	}
+
+	if len(result) == 0 {
+		return nil, diags
+	}
+	return result, diags
+}
+
+func setRouteParamString(params map[string]any, key string, value types.String) {
+	if !value.IsNull() && !value.IsUnknown() && value.ValueString() != "" {
+		params[key] = value.ValueString()
+	}
+}
+
+// routeConnectedAppParamsToObject converts RouteConnectedAppResponse.Params
+// back into the typed params object. Absent params map to a null object.
+func routeConnectedAppParamsToObject(ctx context.Context, params map[string]any) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	attrTypes := routeConnectedAppParamsAttrTypes()
+
+	if len(params) == 0 {
+		return types.ObjectNull(attrTypes), diags
+	}
+
+	raw, err := json.Marshal(params)
+	if err != nil {
+		diags.AddError("Error mapping notification route connected app params", err.Error())
+		return types.ObjectNull(attrTypes), diags
+	}
+	var wire routeConnectedAppParamsWire
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		diags.AddError("Error mapping notification route connected app params", err.Error())
+		return types.ObjectNull(attrTypes), diags
+	}
+
+	channelType := types.ObjectType{AttrTypes: routeConnectedAppChannelAttrTypes()}
+	channelsList := types.ListNull(channelType)
+	if len(wire.Channels) > 0 {
+		channelElements := make([]attr.Value, 0, len(wire.Channels))
+		for _, ch := range wire.Channels {
+			if ch == nil {
+				continue
+			}
+			id := ""
+			if ch.ID != nil {
+				id = *ch.ID
+			}
+			channelObj, channelDiags := types.ObjectValue(routeConnectedAppChannelAttrTypes(), map[string]attr.Value{
+				"id":   types.StringValue(id),
+				"name": routeNullableString(ch.Name),
+			})
+			diags.Append(channelDiags...)
+			channelElements = append(channelElements, channelObj)
+		}
+		list, listDiags := types.ListValue(channelType, channelElements)
+		diags.Append(listDiags...)
+		channelsList = list
+	}
+
+	labelIDs := types.ListNull(types.StringType)
+	if len(wire.LabelIDs) > 0 {
+		list, listDiags := types.ListValueFrom(ctx, types.StringType, wire.LabelIDs)
+		diags.Append(listDiags...)
+		labelIDs = list
+	}
+
+	autoResolve := types.BoolNull()
+	if wire.AutoResolve != nil {
+		autoResolve = types.BoolValue(*wire.AutoResolve)
+	}
+
+	obj, objDiags := types.ObjectValue(attrTypes, map[string]attr.Value{
+		"channels":           channelsList,
+		"team_id":            routeNullableString(wire.TeamID),
+		"assignee_id":        routeNullableString(wire.AssigneeID),
+		"delegate_id":        routeNullableString(wire.DelegateID),
+		"project_id":         routeNullableString(wire.ProjectID),
+		"resolved_status_id": routeNullableString(wire.ResolvedStatusID),
+		"label_ids":          labelIDs,
+		"auto_resolve":       autoResolve,
+	})
+	diags.Append(objDiags...)
+	return obj, diags
+}
+
+func routeNullableString(value string) types.String {
+	if value == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
+}
+
 // Attribute type definitions for nested structures
 
 func routeConnectedAppAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"type": types.StringType,
+		"type":   types.StringType,
+		"id":     types.StringType,
+		"params": types.ObjectType{AttrTypes: routeConnectedAppParamsAttrTypes()},
+	}
+}
+
+func routeConnectedAppParamsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"channels":           types.ListType{ElemType: types.ObjectType{AttrTypes: routeConnectedAppChannelAttrTypes()}},
+		"team_id":            types.StringType,
+		"assignee_id":        types.StringType,
+		"delegate_id":        types.StringType,
+		"project_id":         types.StringType,
+		"resolved_status_id": types.StringType,
+		"label_ids":          types.ListType{ElemType: types.StringType},
+		"auto_resolve":       types.BoolType,
+	}
+}
+
+func routeConnectedAppChannelAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
 		"id":   types.StringType,
+		"name": types.StringType,
 	}
 }
 

--- a/internal/provider/resource_notification_route_test.go
+++ b/internal/provider/resource_notification_route_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	fwvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -666,5 +669,106 @@ func TestNotificationRouteConnectedAppParamsFromSDK(t *testing.T) {
 	wantNull := types.ObjectNull(routeParamsTestAttrTypes())
 	if got := getParams(t, apps[2]); !got.Equal(wantNull) {
 		t.Errorf("expected null params for app without params, got: %v", got)
+	}
+}
+
+// Params values that routeConnectedAppParamsToSDK would silently drop (empty
+// object, empty lists, empty strings) must be rejected at validation time.
+// Otherwise a known non-null plan value round-trips through the API as absent
+// and comes back null, which Terraform reports as an inconsistent result
+// after apply.
+func TestNotificationRouteParamsSchemaValidators(t *testing.T) {
+	ctx := context.Background()
+	r := &notificationRouteResource{}
+	var resp fwresource.SchemaResponse
+	r.Schema(ctx, fwresource.SchemaRequest{}, &resp)
+
+	routes, ok := resp.Schema.Attributes["routes"].(rschema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("unexpected routes attribute type: %T", resp.Schema.Attributes["routes"])
+	}
+	apps, ok := routes.NestedObject.Attributes["connected_apps"].(rschema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("unexpected connected_apps attribute type: %T", routes.NestedObject.Attributes["connected_apps"])
+	}
+	params, ok := apps.NestedObject.Attributes["params"].(rschema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("unexpected params attribute type: %T", apps.NestedObject.Attributes["params"])
+	}
+
+	if len(params.Validators) == 0 {
+		t.Error("params must have a validator rejecting an all-null object")
+	}
+
+	channels, ok := params.Attributes["channels"].(rschema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("unexpected channels attribute type: %T", params.Attributes["channels"])
+	}
+	if len(channels.Validators) == 0 {
+		t.Error("channels must have a validator rejecting an empty list")
+	}
+	for _, name := range []string{"id", "name"} {
+		s, ok := channels.NestedObject.Attributes[name].(rschema.StringAttribute)
+		if !ok {
+			t.Fatalf("unexpected channel %s attribute type: %T", name, channels.NestedObject.Attributes[name])
+		}
+		if len(s.Validators) == 0 {
+			t.Errorf("channel %s must have a validator rejecting an empty string", name)
+		}
+	}
+
+	for _, name := range []string{"team_id", "assignee_id", "delegate_id", "project_id", "resolved_status_id"} {
+		s, ok := params.Attributes[name].(rschema.StringAttribute)
+		if !ok {
+			t.Fatalf("unexpected %s attribute type: %T", name, params.Attributes[name])
+		}
+		if len(s.Validators) == 0 {
+			t.Errorf("%s must have a validator rejecting an empty string", name)
+		}
+	}
+
+	labelIDs, ok := params.Attributes["label_ids"].(rschema.ListAttribute)
+	if !ok {
+		t.Fatalf("unexpected label_ids attribute type: %T", params.Attributes["label_ids"])
+	}
+	if len(labelIDs.Validators) == 0 {
+		t.Error("label_ids must have a validator rejecting an empty list")
+	}
+}
+
+func TestRouteParamsNotEmptyValidator(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		value     types.Object
+		wantError bool
+	}{
+		{"null object", types.ObjectNull(routeParamsTestAttrTypes()), false},
+		{"unknown object", types.ObjectUnknown(routeParamsTestAttrTypes()), false},
+		{"all attributes null", testRouteParamsObject(t, nil), true},
+		{
+			"one attribute set",
+			testRouteParamsObject(t, map[string]attr.Value{"team_id": types.StringValue("T1")}),
+			false,
+		},
+		{
+			// An unknown config value may resolve to a real value at apply
+			// time, so it must not be rejected during validation.
+			"unknown attribute counts as set",
+			testRouteParamsObject(t, map[string]attr.Value{"team_id": types.StringUnknown()}),
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := fwvalidator.ObjectRequest{ConfigValue: tc.value}
+			var resp fwvalidator.ObjectResponse
+			routeParamsNotEmptyValidator{}.ValidateObject(ctx, req, &resp)
+			if resp.Diagnostics.HasError() != tc.wantError {
+				t.Errorf("wantError=%v, got diagnostics: %v", tc.wantError, resp.Diagnostics)
+			}
+		})
 	}
 }

--- a/internal/provider/resource_notification_route_test.go
+++ b/internal/provider/resource_notification_route_test.go
@@ -3,11 +3,19 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
+	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/groundcover-com/groundcover-sdk-go/pkg/models"
 )
 
 func TestAccNotificationRoute_basic(t *testing.T) {
@@ -325,4 +333,338 @@ resource "groundcover_notification_route" "test" {
   }]
 }
 `, name)
+}
+
+// --- Unit tests for routes[*].connected_apps[*].params conversion ---
+
+// routeParamsTestAttrTypes mirrors the expected attribute types of
+// routes[*].connected_apps[*].params. Kept local to the tests so they document
+// the schema contract independently of the implementation.
+func routeParamsTestAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"channels":           types.ListType{ElemType: types.ObjectType{AttrTypes: routeChannelTestAttrTypes()}},
+		"team_id":            types.StringType,
+		"assignee_id":        types.StringType,
+		"delegate_id":        types.StringType,
+		"project_id":         types.StringType,
+		"resolved_status_id": types.StringType,
+		"label_ids":          types.ListType{ElemType: types.StringType},
+		"auto_resolve":       types.BoolType,
+	}
+}
+
+func routeChannelTestAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   types.StringType,
+		"name": types.StringType,
+	}
+}
+
+func testRouteChannel(t *testing.T, id string, name attr.Value) attr.Value {
+	t.Helper()
+	obj, diags := types.ObjectValue(routeChannelTestAttrTypes(), map[string]attr.Value{
+		"id":   types.StringValue(id),
+		"name": name,
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build channel object: %v", diags)
+	}
+	return obj
+}
+
+func testRouteChannelsList(t *testing.T, channels ...attr.Value) attr.Value {
+	t.Helper()
+	list, diags := types.ListValue(types.ObjectType{AttrTypes: routeChannelTestAttrTypes()}, channels)
+	if diags.HasError() {
+		t.Fatalf("failed to build channels list: %v", diags)
+	}
+	return list
+}
+
+// testRouteParamsObject builds a params object with every attribute null, then
+// applies the given overrides.
+func testRouteParamsObject(t *testing.T, overrides map[string]attr.Value) types.Object {
+	t.Helper()
+	values := map[string]attr.Value{
+		"channels":           types.ListNull(types.ObjectType{AttrTypes: routeChannelTestAttrTypes()}),
+		"team_id":            types.StringNull(),
+		"assignee_id":        types.StringNull(),
+		"delegate_id":        types.StringNull(),
+		"project_id":         types.StringNull(),
+		"resolved_status_id": types.StringNull(),
+		"label_ids":          types.ListNull(types.StringType),
+		"auto_resolve":       types.BoolNull(),
+	}
+	maps.Copy(values, overrides)
+	obj, diags := types.ObjectValue(routeParamsTestAttrTypes(), values)
+	if diags.HasError() {
+		t.Fatalf("failed to build params object: %v", diags)
+	}
+	return obj
+}
+
+// testRoutesList builds a routes list with a single rule containing a single
+// connected app with the given params value.
+func testRoutesList(t *testing.T, appType, appID string, params attr.Value) types.List {
+	t.Helper()
+	ctx := context.Background()
+
+	appObj, diags := types.ObjectValue(routeConnectedAppAttrTypes(), map[string]attr.Value{
+		"type":   types.StringValue(appType),
+		"id":     types.StringValue(appID),
+		"params": params,
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build connected app object: %v", diags)
+	}
+
+	appsList, diags := types.ListValue(types.ObjectType{AttrTypes: routeConnectedAppAttrTypes()}, []attr.Value{appObj})
+	if diags.HasError() {
+		t.Fatalf("failed to build connected apps list: %v", diags)
+	}
+
+	statusList, diags := types.ListValueFrom(ctx, types.StringType, []string{"Alerting"})
+	if diags.HasError() {
+		t.Fatalf("failed to build status list: %v", diags)
+	}
+
+	routeObj, diags := types.ObjectValue(routeRuleAttrTypes(), map[string]attr.Value{
+		"status":         statusList,
+		"connected_apps": appsList,
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build route object: %v", diags)
+	}
+
+	routesList, diags := types.ListValue(types.ObjectType{AttrTypes: routeRuleAttrTypes()}, []attr.Value{routeObj})
+	if diags.HasError() {
+		t.Fatalf("failed to build routes list: %v", diags)
+	}
+	return routesList
+}
+
+func assertParamsJSON(t *testing.T, got map[string]any, wantJSON string) {
+	t.Helper()
+	gotBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("failed to marshal params: %v", err)
+	}
+	var gotAny, wantAny any
+	if err := json.Unmarshal(gotBytes, &gotAny); err != nil {
+		t.Fatalf("failed to unmarshal marshaled params: %v", err)
+	}
+	if err := json.Unmarshal([]byte(wantJSON), &wantAny); err != nil {
+		t.Fatalf("invalid expected JSON %q: %v", wantJSON, err)
+	}
+	if !reflect.DeepEqual(gotAny, wantAny) {
+		t.Errorf("params mismatch\ngot:  %s\nwant: %s", gotBytes, wantJSON)
+	}
+}
+
+func TestNotificationRouteConnectedAppParamsToSDK(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		appType  string
+		params   func(t *testing.T) attr.Value
+		wantJSON string // empty means Params must be nil
+	}{
+		{
+			name:    "slack app channels",
+			appType: "slack-app",
+			params: func(t *testing.T) attr.Value {
+				return testRouteParamsObject(t, map[string]attr.Value{
+					"channels": testRouteChannelsList(t,
+						testRouteChannel(t, "C123", types.StringValue("#alerts")),
+						testRouteChannel(t, "C456", types.StringNull()),
+					),
+				})
+			},
+			wantJSON: `{"channels":[{"id":"C123","name":"#alerts"},{"id":"C456"}]}`,
+		},
+		{
+			name:    "linear full options",
+			appType: "linear",
+			params: func(t *testing.T) attr.Value {
+				return testRouteParamsObject(t, map[string]attr.Value{
+					"team_id":            types.StringValue("T1"),
+					"assignee_id":        types.StringValue("U1"),
+					"delegate_id":        types.StringValue("D1"),
+					"project_id":         types.StringValue("P1"),
+					"resolved_status_id": types.StringValue("S1"),
+					"label_ids":          types.ListValueMust(types.StringType, []attr.Value{types.StringValue("L1"), types.StringValue("L2")}),
+					"auto_resolve":       types.BoolValue(true),
+				})
+			},
+			wantJSON: `{"team_id":"T1","assignee_id":"U1","delegate_id":"D1","project_id":"P1","resolved_status_id":"S1","label_ids":["L1","L2"],"auto_resolve":true}`,
+		},
+		{
+			// The backend defaults auto_resolve to true when unset, so an
+			// explicit false must be sent, not dropped.
+			name:    "linear explicit auto_resolve false",
+			appType: "linear",
+			params: func(t *testing.T) attr.Value {
+				return testRouteParamsObject(t, map[string]attr.Value{
+					"team_id":      types.StringValue("T1"),
+					"auto_resolve": types.BoolValue(false),
+				})
+			},
+			wantJSON: `{"team_id":"T1","auto_resolve":false}`,
+		},
+		{
+			name:    "linear unset auto_resolve omitted",
+			appType: "linear",
+			params: func(t *testing.T) attr.Value {
+				return testRouteParamsObject(t, map[string]attr.Value{
+					"team_id": types.StringValue("T1"),
+				})
+			},
+			wantJSON: `{"team_id":"T1"}`,
+		},
+		{
+			// During create, unset computed attributes are unknown in the plan
+			// and must be omitted from the request.
+			name:    "unknown auto_resolve omitted",
+			appType: "linear",
+			params: func(t *testing.T) attr.Value {
+				return testRouteParamsObject(t, map[string]attr.Value{
+					"team_id":      types.StringValue("T1"),
+					"auto_resolve": types.BoolUnknown(),
+				})
+			},
+			wantJSON: `{"team_id":"T1"}`,
+		},
+		{
+			name:    "no params",
+			appType: "slack-webhook",
+			params: func(t *testing.T) attr.Value {
+				return types.ObjectNull(routeParamsTestAttrTypes())
+			},
+			wantJSON: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			routesList := testRoutesList(t, tc.appType, "app-1", tc.params(t))
+
+			sdkRoutes, diags := routesListToSDK(ctx, routesList)
+			if diags.HasError() {
+				t.Fatalf("routesListToSDK returned errors: %v", diags)
+			}
+			if len(sdkRoutes) != 1 || len(sdkRoutes[0].ConnectedApps) != 1 {
+				t.Fatalf("unexpected SDK routes shape: %+v", sdkRoutes)
+			}
+
+			app := sdkRoutes[0].ConnectedApps[0]
+			if app.Type == nil || *app.Type != tc.appType {
+				t.Errorf("unexpected type: %v", app.Type)
+			}
+			if app.ID == nil || *app.ID != "app-1" {
+				t.Errorf("unexpected id: %v", app.ID)
+			}
+
+			if tc.wantJSON == "" {
+				if app.Params != nil {
+					t.Errorf("expected nil Params, got: %+v", app.Params)
+				}
+				return
+			}
+			assertParamsJSON(t, app.Params, tc.wantJSON)
+		})
+	}
+}
+
+func TestNotificationRouteConnectedAppParamsFromSDK(t *testing.T) {
+	ctx := context.Background()
+
+	sdkRoutes := []*models.RouteRuleResponse{
+		{
+			Status: []string{"Alerting"},
+			ConnectedApps: []*models.RouteConnectedAppResponse{
+				{
+					ID:   "app-slack",
+					Type: "slack-app",
+					// Shaped as it arrives from JSON decoding of the API response.
+					Params: map[string]any{
+						"channels": []any{
+							map[string]any{"id": "C123", "name": "#alerts"},
+							map[string]any{"id": "C456"},
+						},
+					},
+				},
+				{
+					ID:   "app-linear",
+					Type: "linear",
+					Params: map[string]any{
+						"team_id":            "T1",
+						"resolved_status_id": "S1",
+						"label_ids":          []any{"L1"},
+						"auto_resolve":       true,
+					},
+				},
+				{
+					ID:   "app-webhook",
+					Type: "slack-webhook",
+				},
+			},
+		},
+	}
+
+	routesList, diags := routesSDKToList(ctx, sdkRoutes)
+	if diags.HasError() {
+		t.Fatalf("routesSDKToList returned errors: %v", diags)
+	}
+
+	routeObj, ok := routesList.Elements()[0].(types.Object)
+	if !ok {
+		t.Fatalf("unexpected route element type: %T", routesList.Elements()[0])
+	}
+	appsList, ok := routeObj.Attributes()["connected_apps"].(types.List)
+	if !ok {
+		t.Fatalf("unexpected connected_apps type: %T", routeObj.Attributes()["connected_apps"])
+	}
+	apps := appsList.Elements()
+	if len(apps) != 3 {
+		t.Fatalf("expected 3 connected apps, got %d", len(apps))
+	}
+
+	getParams := func(t *testing.T, app attr.Value) attr.Value {
+		t.Helper()
+		appObj, ok := app.(types.Object)
+		if !ok {
+			t.Fatalf("unexpected connected app element type: %T", app)
+		}
+		params, ok := appObj.Attributes()["params"]
+		if !ok {
+			t.Fatalf("connected app object has no params attribute: %v", appObj)
+		}
+		return params
+	}
+
+	wantSlack := testRouteParamsObject(t, map[string]attr.Value{
+		"channels": testRouteChannelsList(t,
+			testRouteChannel(t, "C123", types.StringValue("#alerts")),
+			testRouteChannel(t, "C456", types.StringNull()),
+		),
+	})
+	if got := getParams(t, apps[0]); !got.Equal(wantSlack) {
+		t.Errorf("slack params mismatch\ngot:  %v\nwant: %v", got, wantSlack)
+	}
+
+	wantLinear := testRouteParamsObject(t, map[string]attr.Value{
+		"team_id":            types.StringValue("T1"),
+		"resolved_status_id": types.StringValue("S1"),
+		"label_ids":          types.ListValueMust(types.StringType, []attr.Value{types.StringValue("L1")}),
+		"auto_resolve":       types.BoolValue(true),
+	})
+	if got := getParams(t, apps[1]); !got.Equal(wantLinear) {
+		t.Errorf("linear params mismatch\ngot:  %v\nwant: %v", got, wantLinear)
+	}
+
+	wantNull := types.ObjectNull(routeParamsTestAttrTypes())
+	if got := getParams(t, apps[2]); !got.Equal(wantNull) {
+		t.Errorf("expected null params for app without params, got: %v", got)
+	}
 }


### PR DESCRIPTION
# User description
## Summary

Adds an optional typed `params` attribute to `groundcover_notification_route.routes[*].connected_apps`, closing the gap reported by a customer migrating from per-channel Slack webhooks to the `slack-app` connected app ([Linear INF-2781](https://linear.app/groundcover/issue/INF-2781)):

- **`slack-app` routes** — `params.channels`, a list of `{ id (required), name (optional) }` Slack channel objects (required by the backend for this type).
- **`linear` routes** — `params.team_id`, `assignee_id`, `delegate_id`, `project_id`, `resolved_status_id`, `label_ids`, `auto_resolve`.

The shape mirrors `groundcover_monitor_v2.notification_settings.connected_app_params` (SDK `ConnectedAppDeliveryOptions`), and `params` maps to/from `RouteConnectedApp{Request,Response}.Params` on create, update, read, and import. No SDK bump needed — `groundcover-sdk-go` v1.345.0 already carries the field.

### Design notes

- **Crossplane/upjet-safe**: `params` is a typed `SingleNestedAttribute` (no dynamic attributes, no nested maps), so the guardrail test passes as-is and no `_json` sibling resource is required.
- **`auto_resolve` is `Optional + Computed` with no provider default**: the backend defaults it to `true` when unset, so the provider omits it unless explicitly configured (avoiding silent behavior changes and refresh drift) and always sends an explicit `false` rather than dropping it.
- Only explicitly-set params keys are sent, since the backend rejects `params` for connected app types that don't support it.

### Testing

Unit tests cover the conversion in both directions: slack channels, full Linear options, explicit `auto_resolve = false`, unset/unknown `auto_resolve` omission, and absent params round-tripping to a null object. Params can't be covered by acceptance tests because `slack-app`/`linear` connected apps are OAuth-installed and can't be created via the API; the existing CRUD/import/apply-loop acceptance tests cover the schema change for the no-params path (per AGENTS.md, variant coverage belongs in unit tests).

Targets a **minor release (v1.20.0)** — new optional attribute, no breaking changes.

## Checklist

- [x] I have written acceptance tests for my changes — *existing acceptance tests cover the no-params path; params variants are unit-tested (see Testing above)*
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notification routes can now send optional, per-connected-app delivery `params` to connected Slack and Linear apps.
  - You can configure Slack channel routing and Linear routing fields (team, project, labels, assignee/delegate, resolved status, and auto-resolve).
  - Added a new example route that delivers critical alerting and resolved events to both Slack and Linear.

- **Documentation**
  - Updated the notification route resource docs, README usage text, and changelog with the expanded connected-app `params` schema and examples.

- **Bug Fixes**
  - Improved validation to prevent explicitly setting empty connected-app `params` and to keep Terraform plans/state consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add typed <code>params</code> support to <code>groundcover_notification_route</code> so <code>routes[*].connected_apps</code> can round-trip Slack <code>channels</code> and Linear delivery fields through the provider schema and API mapping. Validate empty params, preserve <code>auto_resolve</code> behavior, and keep create, read, update, and import flows consistent in <code>notificationRouteResource</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/122?tool=ast&topic=Docs+and+examples>Docs and examples</a>
        </td><td>Update generated docs, examples, README guidance, and release notes to show the new notification route <code>params</code> usage.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>README.md</li>
<li>docs/resources/notification_route.md</li>
<li>examples/resources/groundcover_notification_route/resource.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omer.karjevsky@groundc...</td><td>Add connected app para...</td><td>July 22, 2026</td></tr>
<tr><td>guy.tabak@groundcover.com</td><td>Merge pull request #11...</td><td>July 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/122?tool=ast&topic=Route+params>Route params</a>
        </td><td>Add typed connected-app <code>params</code> mapping and validation for notification routes, including Slack channel delivery and Linear routing fields.<details><summary>Modified files (2)</summary><ul><li>internal/provider/resource_notification_route.go</li>
<li>internal/provider/resource_notification_route_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omer.karjevsky@groundc...</td><td>Reject params values t...</td><td>July 22, 2026</td></tr>
<tr><td>avital@groundcover.com</td><td>Remove redundant accep...</td><td>May 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/122?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>