### PR TITLE
docs: add awscur data integration example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.21.1
+
+* Add `awscur` example to `groundcover_dataintegration`
+
 ## 1.21.0
 
 * `groundcover_policy` now accepts an empty `data_scope = {}` block, treating it the same as omitting `data_scope` entirely — no data restrictions (access to all data). Previously the provider rejected it with "data_scope must have either 'simple' or 'advanced' specified", forcing tools that always emit the block (e.g. the Crossplane provider) to send an empty `simple` group as a workaround

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -707,18 +707,22 @@ resource "groundcover_dataintegration" "aws_cur_example" {
     version = 1
     enabled = true
 
-    # The data export must live in us-east-1
+    # Base region for the AWS clients; sourceRegion falls back to this
     region = "us-east-1"
 
-    # S3 bucket names are globally unique across all of AWS, so there is no
-    # usable default here — replace this with your own bucket. The placeholder
-    # below is deliberately invalid (S3 rejects uppercase letters) so a
-    # copy-paste fails loudly instead of pointing at someone else's bucket.
-    sourceBucket = "groundcover-cur-REPLACE-ME"
+    # S3 bucket names are globally unique across all of AWS, so replace this with
+    # your own. The placeholder matches the name the stack derives when you don't
+    # pass one (groundcover-cur-integration-<account-id>), with the same fake
+    # account ID as the roleArn below.
+    sourceBucket = "groundcover-cur-integration-123456789012"
+
+    # Region of sourceBucket — only needed when it differs from region. The CUR
+    # export bucket must be us-east-1 (AWS Data Exports only delivers there), so
+    # keep this pinned even if you point region at your own home region.
     sourceRegion = "us-east-1"
 
     # Prefix the export writes under, and the only keys this integration reads
-    sourcePrefix = "billing/data"
+    sourcePrefix = "groundcover-cur-integration"
 
     # Role groundcover assumes to read the CUR objects.
     # stsRegion is required whenever roleArn is set.

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -693,6 +693,48 @@ EOT
   is_paused = false
 }
 
+# Example: AWS Cost and Usage Report (CUR 2.0)
+# Point this at the S3 bucket holding the CUR 2.0 data export and the IAM role
+# groundcover assumes to read it. Create both with the aws_cost_reports_sink
+# stack (bucket + BCM data export + reader role), then wire its outputs here:
+#   sourceBucket = the export's S3 bucket name
+#   sourcePrefix = export_path_prefix output
+#   roleArn      = role_arn output
+resource "groundcover_dataintegration" "aws_cur_example" {
+  type = "awscur"
+  config = jsonencode({
+    name    = "aws-cur"
+    version = 1
+    enabled = true
+
+    # The data export must live in us-east-1
+    region = "us-east-1"
+
+    # S3 bucket names are globally unique across all of AWS, so there is no
+    # usable default here — replace this with your own bucket. The placeholder
+    # below is deliberately invalid (S3 rejects uppercase letters) so a
+    # copy-paste fails loudly instead of pointing at someone else's bucket.
+    sourceBucket = "groundcover-cur-REPLACE-ME"
+    sourceRegion = "us-east-1"
+
+    # Prefix the export writes under, and the only keys this integration reads
+    sourcePrefix = "billing/data"
+
+    # Role groundcover assumes to read the CUR objects.
+    # stsRegion is required whenever roleArn is set.
+    roleArn   = "arn:aws:iam::123456789012:role/groundcover-cur-integration-reader"
+    stsRegion = "us-east-1"
+
+    # Optional - how far back billing periods are processed. Defaults to 12 months.
+    maxBillingPeriodMonths = 12
+
+    labelSettings = {
+      extraLabels = { env = "prod" }
+    }
+  })
+  is_paused = false
+}
+
 # Output the data integration IDs for reference
 output "cloudwatch_dataintegration_id" {
   description = "The ID of the CloudWatch data integration"
@@ -752,6 +794,11 @@ output "postgresql_demo_dataintegration_id" {
 output "postgresql_system_metrics_dataintegration_id" {
   description = "The ID of the PostgreSQL System Metrics data integration"
   value       = groundcover_dataintegration.postgresql_system_metrics_example.id
+}
+
+output "aws_cur_dataintegration_id" {
+  description = "The ID of the AWS Cost and Usage Report data integration"
+  value       = groundcover_dataintegration.aws_cur_example.id
 }
 ```
 

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -692,18 +692,22 @@ resource "groundcover_dataintegration" "aws_cur_example" {
     version = 1
     enabled = true
 
-    # The data export must live in us-east-1
+    # Base region for the AWS clients; sourceRegion falls back to this
     region = "us-east-1"
 
-    # S3 bucket names are globally unique across all of AWS, so there is no
-    # usable default here — replace this with your own bucket. The placeholder
-    # below is deliberately invalid (S3 rejects uppercase letters) so a
-    # copy-paste fails loudly instead of pointing at someone else's bucket.
-    sourceBucket = "groundcover-cur-REPLACE-ME"
+    # S3 bucket names are globally unique across all of AWS, so replace this with
+    # your own. The placeholder matches the name the stack derives when you don't
+    # pass one (groundcover-cur-integration-<account-id>), with the same fake
+    # account ID as the roleArn below.
+    sourceBucket = "groundcover-cur-integration-123456789012"
+
+    # Region of sourceBucket — only needed when it differs from region. The CUR
+    # export bucket must be us-east-1 (AWS Data Exports only delivers there), so
+    # keep this pinned even if you point region at your own home region.
     sourceRegion = "us-east-1"
 
     # Prefix the export writes under, and the only keys this integration reads
-    sourcePrefix = "billing/data"
+    sourcePrefix = "groundcover-cur-integration"
 
     # Role groundcover assumes to read the CUR objects.
     # stsRegion is required whenever roleArn is set.

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -678,6 +678,48 @@ EOT
   is_paused = false
 }
 
+# Example: AWS Cost and Usage Report (CUR 2.0)
+# Point this at the S3 bucket holding the CUR 2.0 data export and the IAM role
+# groundcover assumes to read it. Create both with the aws_cost_reports_sink
+# stack (bucket + BCM data export + reader role), then wire its outputs here:
+#   sourceBucket = the export's S3 bucket name
+#   sourcePrefix = export_path_prefix output
+#   roleArn      = role_arn output
+resource "groundcover_dataintegration" "aws_cur_example" {
+  type = "awscur"
+  config = jsonencode({
+    name    = "aws-cur"
+    version = 1
+    enabled = true
+
+    # The data export must live in us-east-1
+    region = "us-east-1"
+
+    # S3 bucket names are globally unique across all of AWS, so there is no
+    # usable default here — replace this with your own bucket. The placeholder
+    # below is deliberately invalid (S3 rejects uppercase letters) so a
+    # copy-paste fails loudly instead of pointing at someone else's bucket.
+    sourceBucket = "groundcover-cur-REPLACE-ME"
+    sourceRegion = "us-east-1"
+
+    # Prefix the export writes under, and the only keys this integration reads
+    sourcePrefix = "billing/data"
+
+    # Role groundcover assumes to read the CUR objects.
+    # stsRegion is required whenever roleArn is set.
+    roleArn   = "arn:aws:iam::123456789012:role/groundcover-cur-integration-reader"
+    stsRegion = "us-east-1"
+
+    # Optional - how far back billing periods are processed. Defaults to 12 months.
+    maxBillingPeriodMonths = 12
+
+    labelSettings = {
+      extraLabels = { env = "prod" }
+    }
+  })
+  is_paused = false
+}
+
 # Output the data integration IDs for reference
 output "cloudwatch_dataintegration_id" {
   description = "The ID of the CloudWatch data integration"
@@ -737,4 +779,9 @@ output "postgresql_demo_dataintegration_id" {
 output "postgresql_system_metrics_dataintegration_id" {
   description = "The ID of the PostgreSQL System Metrics data integration"
   value       = groundcover_dataintegration.postgresql_system_metrics_example.id
+}
+
+output "aws_cur_dataintegration_id" {
+  description = "The ID of the AWS Cost and Usage Report data integration"
+  value       = groundcover_dataintegration.aws_cur_example.id
 }


### PR DESCRIPTION
# User description
Adds an AWS Cost and Usage Report (CUR 2.0) example to the groundcover_dataintegration docs, mirroring the config the backend's AwsCurConfig expects: sourceBucket/sourcePrefix for the S3 data export, the roleArn groundcover assumes to read it, and the required region/stsRegion fields.

The sourceBucket placeholder is deliberately invalid (S3 rejects uppercase letters) since bucket names are globally unique and no default can work, so a copy-paste fails loudly rather than silently pointing at a bucket someone else owns.

Agent-stamped fields (sinkBucket, sinkPrefix, env, clusterId, rowGroupRows) and scrapeInterval are omitted, matching what the backend's Describe() surfaces as customer-facing config.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] I have written acceptance tests for my changes
- [ ] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality
- [ ] I have updated the README.md with details of changes
- [ ] I have updated the CHANGELOG.md file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Terraform example for configuring an AWS Cost and Usage Report (CUR 2.0) integration that reads exported CUR data from Amazon S3.
  * Includes IAM role access, S3 export parameters, billing lookback limits, and extra environment label settings.
  * Added an output exposing the new integration’s identifier.

* **Documentation**
  * Updated the data integration documentation with the new AWS CUR example.
  * Added a new changelog entry for version 1.21.1 highlighting the addition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an AWS CUR 2.0 Terraform example to <code>groundcover_dataintegration</code>, showing the S3 export bucket, prefix, IAM reader role, and region settings that <code>AwsCurConfig</code> uses to ingest billing data. Update the documentation and changelog so the new integration flow can be copied and referenced end to end.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nir.sagi@groundcover.com</td><td>docs: fix awscur examp...</td><td>July 28, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Merge branch &#x27;main&#x27; in...</td><td>July 23, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/131?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>