### PR TITLE
BE-2671 - Remove inCloud wording from storage management policy docs (1.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.22.0
 
-* Added `groundcover_storage_management_policy` — manages the per-data-type storage retention policy (default retention, cold-storage move duration, and ordered custom rules) on groundcover inCloud backends. Policies are seeded by groundcover and can be updated and imported but not created or deleted — destroying the resource only removes it from Terraform state; the policy version is managed by the backend
+* Added `groundcover_storage_management_policy` — manages the per-data-type storage retention policy (default retention, cold-storage move duration, and ordered custom rules). Policies are seeded by groundcover and can be updated and imported but not created or deleted — destroying the resource only removes it from Terraform state; the policy version is managed by the backend
 * Add `awscur` example to `groundcover_dataintegration`
 
 ## 1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 1.22.1
+
+* Removed the inCloud-only wording from the `groundcover_storage_management_policy` documentation (resource description, docs, and README)
+
 ## 1.22.0
 
-* Added `groundcover_storage_management_policy` — manages the per-data-type storage retention policy (default retention, cold-storage move duration, and ordered custom rules). Policies are seeded by groundcover and can be updated and imported but not created or deleted — destroying the resource only removes it from Terraform state; the policy version is managed by the backend
+* Added `groundcover_storage_management_policy` — manages the per-data-type storage retention policy (default retention, cold-storage move duration, and ordered custom rules) on groundcover inCloud backends. Policies are seeded by groundcover and can be updated and imported but not created or deleted — destroying the resource only removes it from Terraform state; the policy version is managed by the backend
 * Add `awscur` example to `groundcover_dataintegration`
 
 ## 1.21.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Basic usage examples can be found in the `examples/` directory:
 *   **Metrics Pipeline Resource:** [`examples/resources/groundcover_metricspipeline/resource.tf`](./examples/resources/groundcover_metricspipeline/resource.tf)
     *   Demonstrates how to configure metrics relabeling rules (keep/drop metrics, add labels, raw VM relabel rules).
 *   **Storage Management Policy Resource:** [`examples/resources/groundcover_storage_management_policy/resource.tf`](./examples/resources/groundcover_storage_management_policy/resource.tf)
-    *   Demonstrates how to manage the per-data-type retention policy (default retention, cold storage, custom rules) on groundcover inCloud clusters. Policies can be updated but not created or deleted.
+    *   Demonstrates how to manage the per-data-type retention policy (default retention, cold storage, custom rules). Policies can be updated but not created or deleted.
 *   **Dashboard Resource:** [`examples/resources/groundcover_dashboard/resource.tf`](./examples/resources/groundcover_dashboard/resource.tf)
     *   Demonstrates how to create and manage dashboards with customizable widgets and layouts.
 *   **Data Integration Resource:** [`examples/resources/groundcover_dataintegration/resource.tf`](./examples/resources/groundcover_dataintegration/resource.tf)

--- a/docs/resources/storage_management_policy.md
+++ b/docs/resources/storage_management_policy.md
@@ -3,12 +3,12 @@
 page_title: "groundcover_storage_management_policy Resource - groundcover"
 subcategory: ""
 description: |-
-  Manages the groundcover storage management (retention) policy for a single data type. Only supported for groundcover inCloud backends. Policies are seeded by groundcover and can only be updated, never created or deleted — destroying this resource only removes it from Terraform state and leaves the policy active with its current configuration. Applying replaces the entire policy with the configured values: custom rules that are not declared are archived and their names cannot be reused. Adopting a policy whose existing custom rules are not all declared in the configuration fails — terraform import it first and align the configuration.
+  Manages the groundcover storage management (retention) policy for a single data type. Policies are seeded by groundcover and can only be updated, never created or deleted — destroying this resource only removes it from Terraform state and leaves the policy active with its current configuration. Applying replaces the entire policy with the configured values: custom rules that are not declared are archived and their names cannot be reused. Adopting a policy whose existing custom rules are not all declared in the configuration fails — terraform import it first and align the configuration.
 ---
 
 # groundcover_storage_management_policy (Resource)
 
-Manages the groundcover storage management (retention) policy for a single data type. Only supported for groundcover inCloud backends. Policies are seeded by groundcover and can only be updated, never created or deleted — destroying this resource only removes it from Terraform state and leaves the policy active with its current configuration. Applying replaces the entire policy with the configured values: custom rules that are not declared are archived and their names cannot be reused. Adopting a policy whose existing custom rules are not all declared in the configuration fails — `terraform import` it first and align the configuration.
+Manages the groundcover storage management (retention) policy for a single data type. Policies are seeded by groundcover and can only be updated, never created or deleted — destroying this resource only removes it from Terraform state and leaves the policy active with its current configuration. Applying replaces the entire policy with the configured values: custom rules that are not declared are archived and their names cannot be reused. Adopting a policy whose existing custom rules are not all declared in the configuration fails — `terraform import` it first and align the configuration.
 
 ## Example Usage
 

--- a/internal/provider/resource_storagemanagement.go
+++ b/internal/provider/resource_storagemanagement.go
@@ -84,7 +84,6 @@ func (r *storageManagementPolicyResource) Metadata(_ context.Context, req resour
 func (r *storageManagementPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages the groundcover storage management (retention) policy for a single data type. " +
-			"Only supported for groundcover inCloud backends. " +
 			"Policies are seeded by groundcover and can only be updated, never created or deleted — destroying this resource only removes it from Terraform state and leaves the policy active with its current configuration. " +
 			"Applying replaces the entire policy with the configured values: custom rules that are not declared are archived and their names cannot be reused. " +
 			"Adopting a policy whose existing custom rules are not all declared in the configuration fails — `terraform import` it first and align the configuration.",


### PR DESCRIPTION
# User description
## Description
Removes the "only supported for groundcover inCloud backends" statement from the `groundcover_storage_management_policy` documentation — our docs assume all customers are BYOC. Doc-only change, no behavior change.

- Schema `MarkdownDescription` in `internal/provider/resource_storagemanagement.go` + regenerated `docs/resources/storage_management_policy.md`
- README storage-management bullet
- CHANGELOG: new `1.22.1` section recording this change; the released `1.22.0` entry is kept exactly as it shipped

Linear: [BE-2671](https://linear.app/groundcover/issue/BE-2671/remove-incloud-wording-from-storage-management-policy-docs)

## Checklist
- [ ] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality (N/A — doc wording change only)
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Remove the inCloud-only wording from the <code>storageManagementPolicyResource</code> schema description and the generated <code>groundcover_storage_management_policy</code> docs so the resource matches the BYOC-only docs model. Update the README and <code>CHANGELOG.md</code> to record the wording cleanup without changing behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishel.veksler@groundc...</td><td>Bump to 1.22.1: keep 1...</td><td>July 30, 2026</td></tr>
<tr><td>nir.sagi@groundcover.com</td><td>docs: add awscur data ...</td><td>July 28, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/133?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Storage Management Policy documentation to remove outdated inCloud-only limitations.
  * Clarified that retention policies can be updated but not created or deleted.
  * Improved formatting for Terraform import guidance.
* **Chores**
  * Added the documentation update to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->