### PR TITLE
Fix release coverage gate: rename fixture-equality unit test off the TestAcc prefix

### DIFF
--- a/internal/provider/singleton_fixture_test.go
+++ b/internal/provider/singleton_fixture_test.go
@@ -140,7 +140,7 @@ func fixtureTokenRegexp(prefix string) *regexp.Regexp {
 // empty plan for configs that genuinely differ — the test would pass for the wrong
 // reason. Salting makes that easy to get wrong: a token in one fixture and not the
 // other, or two different tokens, reads as a real content change.
-func TestAccPipelineReformattedFixturesAreSemanticallyEqual(t *testing.T) {
+func TestPipelineReformattedFixturesAreSemanticallyEqual(t *testing.T) {
 	tests := []struct {
 		name        string
 		base        string


### PR DESCRIPTION
# User description
## What

Renames `TestAccPipelineReformattedFixturesAreSemanticallyEqual` → `TestPipelineReformattedFixturesAreSemanticallyEqual` in `internal/provider/singleton_fixture_test.go`.

## Why

The v1.22.2 release run failed at `acceptance-test-coverage`:

```
The release acceptance-test matrix does not cover every TestAcc test:
TestAccPipelineReformattedFixturesAreSemanticallyEqual
```

The gate enumerates every `^TestAcc*` test in `./internal/provider` and requires each to be matched by a `run_regex` in the release matrix. The pipeline groups are `^TestAccLogsPipelineResource.*` and `^TestAccTracesPipelineResource.*`, so nothing matches `TestAccPipeline*`. That failure skipped the whole acceptance matrix, which in turn failed the `acceptance-tests` aggregate gate and blocked `goreleaser`.

The test isn't an acceptance test — no `resource.Test`, no `TF_ACC`, no backend credentials. It compares two in-memory fixture strings and only picked up the `TestAcc` prefix by naming accident (introduced in a50c013). Renaming keeps it running in the `unit-tests` job rather than burning a credentialed matrix slot on a test that needs no backend.

## Verification

- `go test ./internal/provider -short -run TestPipelineReformattedFixturesAreSemanticallyEqual -v` — passes (both `logs` and `traces` subtests)
- Ran the `acceptance-test-coverage` script from `release.yml` locally: `All acceptance tests are covered by release matrix groups. (87 tests)`

## Note on releasing

`v1.22.2` is already tagged and its release run failed, so the tag will need to be re-pointed (or a fresh tag cut) after this merges. No CHANGELOG entry here — this is a test-file rename with no user-facing change.

## Checklist

- [x] I have written acceptance tests for my changes — n/a, this removes an accidental acceptance-test prefix; the test itself is unchanged
- [x] I have run `make generate` to update generated docs — n/a, no schema or docs change
- [x] I have added examples demonstrating the new functionality — n/a, no new functionality
- [x] I have updated the README.md with details of changes — n/a, no user-facing change
- [x] I have updated the CHANGELOG.md file — n/a, test-only change, nothing ships to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Rename <code>TestAccPipelineReformattedFixturesAreSemanticallyEqual</code> to <code>TestPipelineReformattedFixturesAreSemanticallyEqual</code> in <code>internal/provider</code> so the fixture-equality check is classified as a unit test instead of an acceptance test. Keep the in-memory <code>singleton_fixture_test</code> comparison logic unchanged while preventing it from consuming release matrix coverage.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>Rename fixture-equalit...</td><td>August 04, 2026</td></tr>
<tr><td>omer.karjevsky@groundc...</td><td>Assert the singleton f...</td><td>August 03, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/135?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Renamed a pipeline fixture test for clearer, more consistent terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->