### PR TITLE
Run the acceptance-coverage gate on PRs, not just on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,33 +35,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Check acceptance test group coverage
-        run: |
-          set -euo pipefail
-          all_tests="$(mktemp)"
-          covered_tests="$(mktemp)"
-          regexes="$(mktemp)"
-
-          go test ./internal/provider -list '^TestAcc' | awk '/^TestAcc/ { print }' | sort -u > "$all_tests"
-          sed -n '/^  acceptance-test-group:/,/^  acceptance-tests:/p' .github/workflows/release.yml \
-            | awk -F"'" '/^[[:space:]]*run_regex: / { print $2 }' > "$regexes"
-
-          if [ ! -s "$regexes" ]; then
-            echo "No acceptance test groups were found in the release workflow."
-            exit 1
-          fi
-
-          while IFS= read -r regex; do
-            go test ./internal/provider -list "$regex" | awk '/^TestAcc/ { print }'
-          done < "$regexes" | sort -u > "$covered_tests"
-
-          uncovered="$(comm -23 "$all_tests" "$covered_tests")"
-          if [ -n "$uncovered" ]; then
-            echo "The release acceptance-test matrix does not cover every TestAcc test:"
-            printf '%s\n' "$uncovered"
-            exit 1
-          fi
-
-          echo "All acceptance tests are covered by release matrix groups."
+        run: ./scripts/check-acceptance-coverage.sh .github/workflows/release.yml
 
   acceptance-test-group:
     name: acceptance-tests / ${{ matrix.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,30 @@ jobs:
           gofmt -s -l .
           exit 1
         fi
-    
+
+
+  # Assert the matrix below still selects every TestAcc test. Without this a renamed or
+  # newly added test drops out of the matrix silently and only surfaces at release time.
+  acceptance-test-coverage:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Check acceptance test group coverage
+      run: ./scripts/check-acceptance-coverage.sh .github/workflows/test.yml
 
   # Run acceptance tests (with API calls)
   acceptance-test-group:
     name: acceptance-tests / ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: unit-tests
+    needs: [unit-tests, acceptance-test-coverage]
     environment: testing
     strategy:
       fail-fast: false
@@ -67,7 +84,7 @@ jobs:
           - name: metrics-pipeline
             run_regex: '^TestAccMetricsPipelineResource.*$'
           - name: monitor
-            run_regex: '^(TestAccMonitorResource.*|TestAccMonitorV2Resource.*|TestAccCustomerApplyLoop_Monitor.*)$'
+            run_regex: '^(TestAccMonitorResource.*|TestAccMonitorV2Resource.*|TestAccMonitorV2JsonResource.*|TestAccCustomerApplyLoop_Monitor.*)$'
           - name: notification-route
             run_regex: '^TestAccNotificationRoute.*$'
           - name: rbac

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,10 @@ test:
 testacc:
 	TF_ACC=1 go test -v -cover -timeout 120m ./...
 
-.PHONY: fmt lint test testacc build install generate
+# Assert every TestAcc test is selected by an acceptance-test matrix group. Needs no
+# credentials — it only lists test names.
+check-acceptance-coverage:
+	./scripts/check-acceptance-coverage.sh .github/workflows/test.yml
+	./scripts/check-acceptance-coverage.sh .github/workflows/release.yml
+
+.PHONY: fmt lint test testacc build install generate check-acceptance-coverage

--- a/scripts/check-acceptance-coverage.sh
+++ b/scripts/check-acceptance-coverage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Assert that every TestAcc test in ./internal/provider is selected by one of the
+# acceptance-test matrix groups in a workflow. A test that matches no group is never
+# run by that workflow — silently, since a group whose regex matches nothing still
+# reports success.
+#
+# Usage: scripts/check-acceptance-coverage.sh <workflow-file>
+
+set -euo pipefail
+
+workflow="${1:-}"
+if [ -z "$workflow" ]; then
+  echo "usage: $0 <workflow-file>" >&2
+  exit 2
+fi
+if [ ! -f "$workflow" ]; then
+  echo "workflow file not found: $workflow" >&2
+  exit 2
+fi
+
+all_tests="$(mktemp)"
+covered_tests="$(mktemp)"
+regexes="$(mktemp)"
+trap 'rm -f "$all_tests" "$covered_tests" "$regexes"' EXIT
+
+go test ./internal/provider -list '^TestAcc' | awk '/^TestAcc/ { print }' | sort -u > "$all_tests"
+
+# Only the acceptance-test-group job's regexes count. Other jobs may name TestAcc
+# tests for unrelated reasons, and matching those would mask a real coverage gap. The
+# block ends at the next job key rather than a specific job name, so renaming the
+# following job cannot silently widen the range to the rest of the file.
+awk -F"'" '
+  /^  acceptance-test-group:/ { in_job = 1; next }
+  in_job && /^  [A-Za-z0-9_-]+:/ { in_job = 0 }
+  in_job && /^[[:space:]]*run_regex: / { print $2 }
+' "$workflow" > "$regexes"
+
+if [ ! -s "$regexes" ]; then
+  echo "No acceptance test groups were found in $workflow."
+  echo "Expected an 'acceptance-test-group:' job with 'run_regex:' matrix entries."
+  exit 1
+fi
+
+while IFS= read -r regex; do
+  go test ./internal/provider -list "$regex" | awk '/^TestAcc/ { print }'
+done < "$regexes" | sort -u > "$covered_tests"
+
+uncovered="$(comm -23 "$all_tests" "$covered_tests")"
+if [ -n "$uncovered" ]; then
+  echo "The acceptance-test matrix in $workflow does not cover every TestAcc test:"
+  printf '%s\n' "$uncovered"
+  echo
+  echo "Add each test to a group's run_regex, or rename it off the TestAcc prefix if"
+  echo "it is a unit test that needs no backend."
+  exit 1
+fi
+
+echo "All $(wc -l < "$all_tests" | tr -d ' ') acceptance tests are covered by the matrix groups in $workflow."


### PR DESCRIPTION
# User description
Follow-up to #135, which fixed a broken v1.22.2 release. This closes the gap that let it break in the first place.

## Why

The gate that asserts every `TestAcc*` test is selected by some acceptance-test matrix group lived only in [release.yml](.github/workflows/release.yml), which triggers on `push: tags: v*`. The PR workflows carried the same matrix but no gate, so a test could drift out of coverage for any number of PRs and only surface when someone cut a release — at the worst possible moment. That's exactly how #135 happened: the offending test landed on 2026-08-03, and `v1.22.2` was the first tag containing it.

## What

- Extract the check to `scripts/check-acceptance-coverage.sh`, taking the workflow to validate as an argument
- Run it from **test.yml** (per PR, gating `acceptance-test-group`) and **release.yml** (per tag), so each workflow validates its *own* matrix — the two lists are separate copies and can drift independently
- `make check-acceptance-coverage` for local runs — no credentials needed, it only lists test names
- The extracted version ends the matrix block at the next job key rather than the hardcoded `acceptance-tests:` name, so renaming the following job can't silently widen the parsed range

## Existing gap this found

Pointing the gate at test.yml's own matrix immediately failed:

```
TestAccMonitorV2JsonResource_basic
```

test.yml's monitor group was `^(TestAccMonitorResource.*|TestAccMonitorV2Resource.*|TestAccCustomerApplyLoop_Monitor.*)$` — and `TestAccMonitorV2JsonResource` does not match `TestAccMonitorV2Resource.*` (`Json` sits where `Resource` is expected). release.yml's copy had the `TestAccMonitorV2JsonResource.*` alternative; test.yml's never did, so **that test had never run on a PR**. Added it to the group.

Note this means `TestAccMonitorV2JsonResource_basic` now runs on every PR — real coverage that was missing, at the cost of one more test in the monitor group.

## Verification

- `make check-acceptance-coverage` — both workflows pass: `All 87 acceptance tests are covered by the matrix groups in ...`
- Both workflow files parse as YAML; job graph confirmed: `acceptance-test-group needs=[unit-tests, acceptance-test-coverage]` in each
- Negative tests, all behaving correctly:
  - regex alternative removed from a group → exits 1, names the uncovered test
  - `acceptance-test-group` job renamed away → exits 1 ("No acceptance test groups were found"), rather than passing vacuously
  - no argument / missing file → exits 2 with usage

## Checklist

- [x] I have written acceptance tests for my changes — n/a, CI-only change; verified by running the gate against known-good and known-bad workflow inputs (above)
- [x] I have run `make generate` to update generated docs — n/a, no schema or docs change
- [x] I have added examples demonstrating the new functionality — n/a, no provider functionality
- [x] I have updated the README.md with details of changes — n/a, no user-facing change
- [x] I have updated the CHANGELOG.md file — n/a, CI-only change, nothing ships to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a reusable <code>check-acceptance-coverage.sh</code> gate that verifies every <code>TestAcc*</code> test is matched by an acceptance-test matrix group in both <code>test.yml</code> and <code>release.yml</code>, and expose it through <code>make check-acceptance-coverage</code>. Update the monitor acceptance matrix to include <code>TestAccMonitorV2JsonResource.*</code>, so the PR workflow now runs the test that had been missing coverage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/136?tool=ast&topic=Monitor+matrix>Monitor matrix</a>
        </td><td>Expand the monitor acceptance matrix in <code>test.yml</code> to match <code>TestAccMonitorV2JsonResource.*</code>, restoring the missing PR-time coverage for that test.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/test.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>Run the acceptance-cov...</td><td>August 04, 2026</td></tr>
<tr><td>thehecticbyte@gmail.com</td><td>feat: add organization...</td><td>July 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/136?tool=ast&topic=Coverage+gate>Coverage gate</a>
        </td><td>Extract a workflow-aware acceptance coverage check into <code>scripts/check-acceptance-coverage.sh</code> and wire it into <code>test.yml</code>, <code>release.yml</code>, and <code>Makefile</code> so PRs and tags both verify <code>TestAcc</code> coverage.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/release.yml</li>
<li>.github/workflows/test.yml</li>
<li>Makefile</li>
<li>scripts/check-acceptance-coverage.sh</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>Run the acceptance-cov...</td><td>August 04, 2026</td></tr>
<tr><td>me@naor.dev</td><td>ci: align release conf...</td><td>July 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/136?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation to ensure all acceptance tests are included in workflow coverage.
  * Expanded monitoring test coverage checks to include additional JSON resource tests.
  * Acceptance test execution now requires both unit tests and coverage validation to pass.

* **Chores**
  * Standardized acceptance-test coverage checks for local and release workflows.
  * Improved failure reporting when tests are missing from workflow groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->