### PR TITLE
BE-2663 - fix: keep groundcover_dashboard description null when omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.22.3
 
-* Fixed `groundcover_dashboard` failing `terraform apply` with "provider produced inconsistent result after apply" when `description` was omitted — the API returns an empty string for an unset description, which the provider wrote over the `null` Terraform planned. Omitting `description` now leaves the attribute unset in state, and the `description = ""` workaround is no longer needed. Dashboards whose state still holds the empty string recorded by an earlier version plan one no-op update on the first apply after upgrading, which rewrites the attribute to unset; explicitly configured `description = ""` keeps working unchanged
+* Fixed `groundcover_dashboard` failing `terraform apply` when `description` is omitted
 
 ## 1.22.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.22.3
 
-* Fixed `groundcover_dashboard` failing `terraform apply` with "provider produced inconsistent result after apply" when `description` was omitted — the API returns an empty string for an unset description, which the provider wrote over the `null` Terraform planned. Omitting `description` now leaves the attribute unset in state, and the `description = ""` workaround is no longer needed
+* Fixed `groundcover_dashboard` failing `terraform apply` with "provider produced inconsistent result after apply" when `description` was omitted — the API returns an empty string for an unset description, which the provider wrote over the `null` Terraform planned. Omitting `description` now leaves the attribute unset in state, and the `description = ""` workaround is no longer needed. Dashboards whose state still holds the empty string recorded by an earlier version plan one no-op update on the first apply after upgrading, which rewrites the attribute to unset; explicitly configured `description = ""` keeps working unchanged
 
 ## 1.22.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.3
+
+* Fixed `groundcover_dashboard` failing `terraform apply` with "provider produced inconsistent result after apply" when `description` was omitted — the API returns an empty string for an unset description, which the provider wrote over the `null` Terraform planned. Omitting `description` now leaves the attribute unset in state, and the `description = ""` workaround is no longer needed
+
 ## 1.22.2
 
 * Add documentation for the consolidated aws data integration

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -178,12 +178,8 @@ func (r *dashboardResource) Create(ctx context.Context, req resource.CreateReque
 
 	plan.UUID = types.StringValue(dashboard.UUID)
 	plan.Name = types.StringValue(dashboard.Name)
-	plan.Description = types.StringValue(dashboard.Description)
-	if plan.Team.IsNull() && dashboard.Team == "" {
-		plan.Team = types.StringNull()
-	} else {
-		plan.Team = types.StringValue(dashboard.Team)
-	}
+	plan.Description = optionalStringToState(dashboard.Description, plan.Description)
+	plan.Team = optionalStringToState(dashboard.Team, plan.Team)
 	// Keep the user's original preset format if semantically the same
 	apiPresetStr := dashboard.Preset
 	areSemanticallySame, err := CompareJSONSemantically(planPresetStr, apiPresetStr)
@@ -292,12 +288,8 @@ func (r *dashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	state.UUID = types.StringValue(dashboard.UUID)
 	state.Name = types.StringValue(dashboard.Name)
-	state.Description = types.StringValue(dashboard.Description)
-	if state.Team.IsNull() && dashboard.Team == "" {
-		state.Team = types.StringNull()
-	} else {
-		state.Team = types.StringValue(dashboard.Team)
-	}
+	state.Description = optionalStringToState(dashboard.Description, state.Description)
+	state.Team = optionalStringToState(dashboard.Team, state.Team)
 
 	// Normalize both presets for detailed comparison logging
 	normalizedStatePreset, errStateNorm := NormalizeJSON(ctx, originalStatePreset)
@@ -475,12 +467,8 @@ func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateReque
 
 	plan.UUID = types.StringValue(dashboard.UUID)
 	plan.Name = types.StringValue(dashboard.Name)
-	plan.Description = types.StringValue(dashboard.Description)
-	if plan.Team.IsNull() && dashboard.Team == "" {
-		plan.Team = types.StringNull()
-	} else {
-		plan.Team = types.StringValue(dashboard.Team)
-	}
+	plan.Description = optionalStringToState(dashboard.Description, plan.Description)
+	plan.Team = optionalStringToState(dashboard.Team, plan.Team)
 	// Keep the user's original preset format if semantically the same
 	// This prevents format drift when the API returns semantically identical but differently formatted JSON
 	// The ModifyPlan method normalizes and compares during plan phase, so plan.Preset should already
@@ -789,6 +777,21 @@ func (r *dashboardResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 	}
 
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+// optionalStringToState maps an API string back onto an Optional, non-computed
+// string attribute. The API has no notion of "unset" for these fields and
+// returns "" for both an omitted and an explicitly empty value, while Terraform
+// distinguishes null (omitted from config) from "". Writing "" over a null plan
+// value fails the apply with "provider produced inconsistent result after
+// apply", so an empty API value keeps the attribute null when the config left it
+// unset. Anything else — a value from the API, or an explicitly configured "" —
+// is stored as-is, so a value set out-of-band still surfaces as drift.
+func optionalStringToState(apiValue string, prior types.String) types.String {
+	if apiValue == "" && prior.IsNull() {
+		return types.StringNull()
+	}
+	return types.StringValue(apiValue)
 }
 
 // tagsToStringSlice converts the Terraform tags list into a []string for the

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -782,11 +782,19 @@ func (r *dashboardResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 // optionalStringToState maps an API string back onto an Optional, non-computed
 // string attribute. The API has no notion of "unset" for these fields and
 // returns "" for both an omitted and an explicitly empty value, while Terraform
-// distinguishes null (omitted from config) from "". Writing "" over a null plan
-// value fails the apply with "provider produced inconsistent result after
-// apply", so an empty API value keeps the attribute null when the config left it
-// unset. Anything else — a value from the API, or an explicitly configured "" —
-// is stored as-is, so a value set out-of-band still surfaces as drift.
+// distinguishes null (omitted from config) from "".
+//
+// prior is the attribute's previous Terraform value: the planned value in Create
+// and Update, the persisted state in Read. Writing "" over a null planned value
+// fails the apply with "provider produced inconsistent result after apply", so
+// an empty API value keeps the attribute null whenever prior is already null.
+// Anything else — a value from the API, or an explicitly configured "" — is
+// stored as-is, so a value set out-of-band still surfaces as drift.
+//
+// Import has no prior value, so an API "" imports as null. The API cannot tell
+// an omitted value from an explicitly empty one, so no import path can recover
+// that distinction; null is correct for the common (omitted) case, and a config
+// that explicitly sets "" plans a single converging update after import.
 func optionalStringToState(apiValue string, prior types.String) types.String {
 	if apiValue == "" && prior.IsNull() {
 		return types.StringNull()

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -281,6 +281,19 @@ func TestAccDashboardResource_OmittedDescription(t *testing.T) {
 					resource.TestCheckNoResourceAttr("groundcover_dashboard.test", "description"),
 				),
 			},
+			// `description = ""` was the workaround for this bug, so configs in
+			// the wild still carry it — an explicit empty string must keep
+			// applying cleanly and stay empty rather than being folded to null.
+			{
+				Config: testAccDashboardResourceConfigEmptyDescription(dashboardName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", ""),
+				),
+			},
+			{
+				Config:   testAccDashboardResourceConfigEmptyDescription(dashboardName),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -497,6 +510,22 @@ func testAccDashboardResourceConfigNoDescription(name string) string {
 	return fmt.Sprintf(`
 resource "groundcover_dashboard" "test" {
   name        = "%s"
+  preset      = jsonencode({
+    duration      = "Last 1 hour"
+    widgets       = []
+    layout        = []
+    variables     = {}
+    schemaVersion = 3
+  })
+}
+`, name)
+}
+
+func testAccDashboardResourceConfigEmptyDescription(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_dashboard" "test" {
+  name        = "%s"
+  description = ""
   preset      = jsonencode({
     duration      = "Last 1 hour"
     widgets       = []

--- a/internal/provider/resource_dashboard_test.go
+++ b/internal/provider/resource_dashboard_test.go
@@ -7,9 +7,59 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+func TestOptionalStringToState(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiValue string
+		prior    types.String
+		expected types.String
+	}{
+		{
+			name:     "unset in config and empty from api stays null",
+			apiValue: "",
+			prior:    types.StringNull(),
+			expected: types.StringNull(),
+		},
+		{
+			name:     "explicitly empty in config stays empty",
+			apiValue: "",
+			prior:    types.StringValue(""),
+			expected: types.StringValue(""),
+		},
+		{
+			name:     "set out-of-band while unset in config surfaces as drift",
+			apiValue: "from the ui",
+			prior:    types.StringNull(),
+			expected: types.StringValue("from the ui"),
+		},
+		{
+			name:     "cleared out-of-band while set in config surfaces as drift",
+			apiValue: "",
+			prior:    types.StringValue("configured"),
+			expected: types.StringValue(""),
+		},
+		{
+			name:     "value round-trips unchanged",
+			apiValue: "configured",
+			prior:    types.StringValue("configured"),
+			expected: types.StringValue("configured"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := optionalStringToState(tt.apiValue, tt.prior)
+			if !got.Equal(tt.expected) {
+				t.Errorf("optionalStringToState(%q, %s) = %s, want %s", tt.apiValue, tt.prior, got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestAccDashboardResource(t *testing.T) {
 	timestamp := time.Now().Unix()
@@ -172,6 +222,63 @@ func TestAccDashboardResource_EmptyTeam(t *testing.T) {
 					resource.TestCheckResourceAttr("groundcover_dashboard.test", "name", dashboardName),
 					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", "Updated empty team dashboard"),
 					resource.TestCheckNoResourceAttr("groundcover_dashboard.test", "team"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDashboardResource_OmittedDescription covers the regression where omitting
+// `description` failed the apply with "provider produced inconsistent result after
+// apply" — the API returns "" for an unset description while Terraform expected the
+// null it planned.
+func TestAccDashboardResource_OmittedDescription(t *testing.T) {
+	timestamp := time.Now().Unix()
+	dashboardName := fmt.Sprintf("no_description_dashboard_%d", timestamp)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create without description — the apply must succeed and leave the
+			// attribute unset rather than storing "".
+			{
+				Config: testAccDashboardResourceConfigNoDescription(dashboardName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "name", dashboardName),
+					resource.TestCheckNoResourceAttr("groundcover_dashboard.test", "description"),
+					resource.TestCheckResourceAttrSet("groundcover_dashboard.test", "id"),
+				),
+			},
+			// Re-apply the same config — refresh must not turn the unset
+			// description into a perpetual diff.
+			{
+				Config:   testAccDashboardResourceConfigNoDescription(dashboardName),
+				PlanOnly: true,
+			},
+			// Import with no description set, to verify the API-to-state mapping
+			// keeps the attribute null.
+			{
+				ResourceName:      "groundcover_dashboard.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"override",
+					"preset",
+				},
+			},
+			// Set a description, then remove it again — going back to unset must
+			// also stay consistent.
+			{
+				Config: testAccDashboardResourceConfigSimple(dashboardName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("groundcover_dashboard.test", "description", "Simple test dashboard"),
+				),
+			},
+			{
+				Config: testAccDashboardResourceConfigNoDescription(dashboardName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("groundcover_dashboard.test", "description"),
 				),
 			},
 		},
@@ -375,6 +482,21 @@ func testAccDashboardResourceConfigSimple(name string) string {
 resource "groundcover_dashboard" "test" {
   name        = "%s"
   description = "Simple test dashboard"
+  preset      = jsonencode({
+    duration      = "Last 1 hour"
+    widgets       = []
+    layout        = []
+    variables     = {}
+    schemaVersion = 3
+  })
+}
+`, name)
+}
+
+func testAccDashboardResourceConfigNoDescription(name string) string {
+	return fmt.Sprintf(`
+resource "groundcover_dashboard" "test" {
+  name        = "%s"
   preset      = jsonencode({
     duration      = "Last 1 hour"
     widgets       = []


### PR DESCRIPTION
# User description
Fixes [BE-2663](https://linear.app/groundcover/issue/BE-2663/terraform-provider-fix-groundcover-dashboard-state-mismatch-when).

## The bug

`groundcover_dashboard` failed `terraform apply` with `provider produced inconsistent result after apply` whenever `description` was omitted, even though the dashboard was created or updated successfully. The workaround was to explicitly set `description = ""`.

`description` is `Optional` and non-computed, so omitting it plans a `null`. All three write paths did:

```go
plan.Description = types.StringValue(dashboard.Description)
```

and the API returns `""` for an unset description — writing `""` over the planned `null` is precisely what Terraform rejects. `team` already carried an inline guard for this; `description` never got one.

## The fix

Added `optionalStringToState`, which maps an API string back onto an `Optional`, non-computed attribute: an empty API value keeps the attribute `null` when the config left it unset, and anything else — a real value from the API, or an explicitly configured `""` — is stored as-is, so a value set out-of-band still surfaces as drift.

Applied to both `description` and `team` in `Create`, `Read`, and `Update`, replacing the three copies of the inlined `team` conditional.

## Tests

- `TestOptionalStringToState` — unit table covering unset/empty, explicit `""`, and drift in both directions.
- `TestAccDashboardResource_OmittedDescription` — create with no `description` (applies cleanly, attribute stays unset), re-apply `PlanOnly` for no perpetual diff, import verify, then set a description and remove it again. Covered by the existing `^TestAccDashboardResource.*$` matrix group, so `check-acceptance-coverage` stays green.

## Checklist

- [x] I have written acceptance tests for my changes
- [x] I have run `make generate` to update generated docs (no diff — schema descriptions unchanged)
- [ ] I have added examples demonstrating the new functionality — n/a, bug fix; the example already sets a description
- [ ] I have updated the README.md with details of changes — n/a, no new resource or attribute
- [x] I have updated the CHANGELOG.md file (new `1.22.3` section — `v1.22.2` is the latest tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve Terraform <code>null</code> state for omitted <code>groundcover_dashboard</code> descriptions while retaining explicit empty strings and surfacing out-of-band changes. Update dashboard create, read, and update flows with <code>optionalStringToState</code>, and add unit and acceptance regression coverage plus changelog documentation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/138?tool=ast&topic=Regression+coverage>Regression coverage</a>
        </td><td>Validate omitted, explicit-empty, imported, updated, and removed descriptions through unit and acceptance tests to prevent apply failures and perpetual diffs.<details><summary>Modified files (1)</summary><ul><li>internal/provider/resource_dashboard_test.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omer.karjevsky@groundc...</td><td>Clarify optionalString...</td><td>August 12, 2026</td></tr>
<tr><td>rotem.zecharia@groundc...</td><td>Drop trimmed-empty das...</td><td>July 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/138?tool=ast&topic=Dashboard+state+consistency>Dashboard state consistency</a>
        </td><td>Preserve omitted optional dashboard strings as <code>null</code> across create, read, and update operations while maintaining correct drift behavior for <code>description</code> and <code>team</code>.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>internal/provider/resource_dashboard.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omer.karjevsky@groundc...</td><td>Shorten the dashboard ...</td><td>August 12, 2026</td></tr>
<tr><td>mishel.veksler@groundc...</td><td>Update CHANGELOG.md</td><td>August 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/138?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard apply failures when the optional description is omitted.
  * Empty descriptions returned by the service no longer overwrite an unset description.
  * Removed the need to set `description = ""` as a workaround.
  * Improved handling of optional team and description values to prevent inconsistent state and recurring diffs.

* **Tests**
  * Added coverage for omitted and explicitly empty descriptions across creation, refresh, import, updates, removal, and no-diff scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->