### PR TITLE
fix: monitor_v2 supports exactly one threshold block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.4
+
+* `groundcover_monitor_v2` and `groundcover_monitor_v2_json` now reject more than one `threshold` block at plan time. A monitor evaluates a single threshold, so extra blocks were accepted by the API and silently ignored. The schema description and docs said "at least one threshold block", which read as multi-threshold support
+
 ## 1.22.3
 
 * Fixed normalization of day/week relative time ranges in `groundcover_monitor_v2` and `groundcover_monitor_v2_json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.22.4
 
-* `groundcover_monitor_v2` and `groundcover_monitor_v2_json` now reject more than one `threshold` block at plan time. A monitor evaluates a single threshold, so extra blocks were accepted by the API and silently ignored. The schema description and docs said "at least one threshold block", which read as multi-threshold support
+* `groundcover_monitor_v2` and `groundcover_monitor_v2_json` now warn at plan time when more than one `threshold` block is configured. A monitor evaluates a single threshold, so only the first block takes effect and the rest are ignored; a future major version will reject them. The schema description and docs said "at least one threshold block", which read as multi-threshold support
 
 ## 1.22.3
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -228,7 +228,7 @@ resource "groundcover_monitor_v2" "gcql_logs" {
 *   `severity` (String, Required): Monitor severity.
 *   `measurement_type` (String, Required): `state` or `event`.
 *   `query` (Block, Required): Typed query definition. Supports `type = "gcql"`, `type = "metricsql"`, and `type = "raw_sql"`. GCQL supports `data_type` values `logs`, `traces`, `events`, and `apm`.
-*   `threshold` (Block, Required): One or more threshold definitions. Supports optional `custom_resolve_threshold`.
+*   `threshold` (Block, Required): Exactly one threshold definition. Supports optional `custom_resolve_threshold`.
 *   `notification_settings` (Block, Optional): Notification behavior, including `connected_app_params` for per-app Slack channels.
 *   `display`, `evaluation_interval`, `reducer`, `labels`, `annotations`, and `routing` are optional monitor settings.
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -280,7 +280,7 @@ resource "groundcover_monitor_v2" "raw_sql" {
 - `reducer` (Block List) Reducers that aggregate or transform query results before threshold evaluation. (see [below for nested schema](#nestedblock--reducer))
 - `routing` (List of String) Routing destinations for the monitor.
 - `team` (String) Team associated with the monitor.
-- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level. (see [below for nested schema](#nestedblock--threshold))
+- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; a monitor evaluates a single threshold. For several alert levels, a separate monitor can cover each level. (see [below for nested schema](#nestedblock--threshold))
 
 ### Read-Only
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -280,7 +280,7 @@ resource "groundcover_monitor_v2" "raw_sql" {
 - `reducer` (Block List) Reducers that aggregate or transform query results before threshold evaluation. (see [below for nested schema](#nestedblock--reducer))
 - `routing` (List of String) Routing destinations for the monitor.
 - `team` (String) Team associated with the monitor.
-- `threshold` (Block List) Required. Thresholds that decide when the monitor fires. At least one threshold block must be configured. (see [below for nested schema](#nestedblock--threshold))
+- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level. (see [below for nested schema](#nestedblock--threshold))
 
 ### Read-Only
 

--- a/docs/resources/monitor_v2_json.md
+++ b/docs/resources/monitor_v2_json.md
@@ -81,7 +81,7 @@ resource "groundcover_monitor_v2_json" "gcql_logs" {
 - `reducer` (Block List) Reducers that aggregate or transform query results before threshold evaluation. (see [below for nested schema](#nestedblock--reducer))
 - `routing` (List of String) Routing destinations for the monitor.
 - `team` (String) Team associated with the monitor.
-- `threshold` (Block List) Required. Thresholds that decide when the monitor fires. At least one threshold block must be configured. (see [below for nested schema](#nestedblock--threshold))
+- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level. (see [below for nested schema](#nestedblock--threshold))
 
 ### Read-Only
 

--- a/docs/resources/monitor_v2_json.md
+++ b/docs/resources/monitor_v2_json.md
@@ -81,7 +81,7 @@ resource "groundcover_monitor_v2_json" "gcql_logs" {
 - `reducer` (Block List) Reducers that aggregate or transform query results before threshold evaluation. (see [below for nested schema](#nestedblock--reducer))
 - `routing` (List of String) Routing destinations for the monitor.
 - `team` (String) Team associated with the monitor.
-- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level. (see [below for nested schema](#nestedblock--threshold))
+- `threshold` (Block List) Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; a monitor evaluates a single threshold. For several alert levels, a separate monitor can cover each level. (see [below for nested schema](#nestedblock--threshold))
 
 ### Read-Only
 

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -1032,6 +1032,38 @@ func TestMonitorV2ValidateCustomResolveValues(t *testing.T) {
 	}
 }
 
+// TestMonitorV2ValidateThresholdCount checks that the plan rejects zero and more than one
+// threshold block: the backend evaluates a single threshold, so extra blocks would be accepted by
+// the API and silently ignored.
+func TestMonitorV2ValidateThresholdCount(t *testing.T) {
+	ctx := context.Background()
+	query := &monitorV2QueryModel{
+		Type:       types.StringValue(monitorV2QueryTypeGCQL),
+		Expression: types.StringValue("level:error | stats count() c"),
+		DataType:   types.StringValue("logs"),
+	}
+
+	none := testMonitorV2BasePlan(t, query)
+	none.Thresholds = nil
+	var diags diag.Diagnostics
+	validateMonitorV2Config(ctx, &none, &diags)
+	requireDiagnosticSummary(t, diags, "Missing threshold block")
+
+	two := testMonitorV2BasePlan(t, query)
+	two.Thresholds = append(two.Thresholds, two.Thresholds[0])
+	two.Thresholds[1].Name = types.StringValue("threshold_2")
+	diags = nil
+	validateMonitorV2Config(ctx, &two, &diags)
+	requireDiagnosticSummary(t, diags, "Too many threshold blocks")
+
+	one := testMonitorV2BasePlan(t, query)
+	diags = nil
+	validateMonitorV2Config(ctx, &one, &diags)
+	if diags.HasError() {
+		t.Errorf("a single threshold block should validate, got diagnostics: %v", diags)
+	}
+}
+
 func TestAccMonitorResource(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-monitor")
 	updatedName := acctest.RandomWithPrefix("test-monitor-updated")

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -1032,9 +1032,24 @@ func TestMonitorV2ValidateCustomResolveValues(t *testing.T) {
 	}
 }
 
-// TestMonitorV2ValidateThresholdCount checks that the plan rejects zero threshold blocks and warns
-// without failing on more than one: a monitor evaluates a single threshold, so extra blocks are
-// accepted by the API and never reach the alert condition.
+// requireSoleDiagnostic asserts that diagnostics hold exactly one entry, of the given severity and
+// with the given summary. Summary-only matching would pass on the wrong severity, and an
+// error/warning count would pass alongside unrelated diagnostics.
+func requireSoleDiagnostic(t *testing.T, diagnostics diag.Diagnostics, severity diag.Severity, summary string) {
+	t.Helper()
+
+	if len(diagnostics) != 1 {
+		t.Fatalf("want exactly 1 diagnostic %q, got %d: %v", summary, len(diagnostics), diagnostics)
+	}
+	if got := diagnostics[0]; got.Severity() != severity || !strings.Contains(got.Summary(), summary) {
+		t.Fatalf("want %v %q, got %v %q", severity, summary, got.Severity(), got.Summary())
+	}
+}
+
+// TestMonitorV2ValidateThresholdCount pins the whole threshold-count contract: zero blocks are an
+// error, one is silent, and more than one is a warning and nothing worse. A monitor evaluates a
+// single threshold, so extra blocks are accepted by the API and never reach the alert condition.
+// The last case runs through the JSON model's bridge, the other entry point into this validator.
 func TestMonitorV2ValidateThresholdCount(t *testing.T) {
 	ctx := context.Background()
 	query := &monitorV2QueryModel{
@@ -1043,28 +1058,41 @@ func TestMonitorV2ValidateThresholdCount(t *testing.T) {
 		DataType:   types.StringValue("logs"),
 	}
 
+	withTwo := func() monitorV2ResourceModel {
+		plan := testMonitorV2BasePlan(t, query)
+		plan.Thresholds = append(plan.Thresholds, plan.Thresholds[0])
+		plan.Thresholds[1].Name = types.StringValue("threshold_2")
+		return plan
+	}
+
 	none := testMonitorV2BasePlan(t, query)
 	none.Thresholds = nil
 	var diags diag.Diagnostics
 	validateMonitorV2Config(ctx, &none, &diags)
-	requireDiagnosticSummary(t, diags, "Missing threshold block")
-
-	two := testMonitorV2BasePlan(t, query)
-	two.Thresholds = append(two.Thresholds, two.Thresholds[0])
-	two.Thresholds[1].Name = types.StringValue("threshold_2")
-	diags = nil
-	validateMonitorV2Config(ctx, &two, &diags)
-	requireDiagnosticSummary(t, diags, "Extra threshold blocks are ignored")
-	if diags.HasError() {
-		t.Errorf("extra threshold blocks should warn, not fail the plan, got: %v", diags)
-	}
+	requireSoleDiagnostic(t, diags, diag.SeverityError, "Missing threshold block")
 
 	one := testMonitorV2BasePlan(t, query)
 	diags = nil
 	validateMonitorV2Config(ctx, &one, &diags)
-	if diags.HasError() {
-		t.Errorf("a single threshold block should validate, got diagnostics: %v", diags)
+	if len(diags) != 0 {
+		t.Errorf("a single threshold block should validate silently, got: %v", diags)
 	}
+
+	two := withTwo()
+	diags = nil
+	validateMonitorV2Config(ctx, &two, &diags)
+	requireSoleDiagnostic(t, diags, diag.SeverityWarning, "Extra threshold blocks are ignored")
+
+	// groundcover_monitor_v2_json reaches the same validator through toTyped.
+	typedTwo := withTwo()
+	diags = nil
+	jsonTwo := monitorV2JsonModelFromTyped(ctx, &typedTwo, &diags)
+	if diags.HasError() {
+		t.Fatalf("building the JSON model: %v", diags)
+	}
+	diags = nil
+	validateMonitorV2Config(ctx, jsonTwo.toTyped(ctx, &diags), &diags)
+	requireSoleDiagnostic(t, diags, diag.SeverityWarning, "Extra threshold blocks are ignored")
 }
 
 func TestAccMonitorResource(t *testing.T) {

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -1032,9 +1032,9 @@ func TestMonitorV2ValidateCustomResolveValues(t *testing.T) {
 	}
 }
 
-// TestMonitorV2ValidateThresholdCount checks that the plan rejects zero and more than one
-// threshold block: the backend evaluates a single threshold, so extra blocks would be accepted by
-// the API and silently ignored.
+// TestMonitorV2ValidateThresholdCount checks that the plan rejects zero threshold blocks and warns
+// without failing on more than one: a monitor evaluates a single threshold, so extra blocks are
+// accepted by the API and never reach the alert condition.
 func TestMonitorV2ValidateThresholdCount(t *testing.T) {
 	ctx := context.Background()
 	query := &monitorV2QueryModel{
@@ -1054,7 +1054,10 @@ func TestMonitorV2ValidateThresholdCount(t *testing.T) {
 	two.Thresholds[1].Name = types.StringValue("threshold_2")
 	diags = nil
 	validateMonitorV2Config(ctx, &two, &diags)
-	requireDiagnosticSummary(t, diags, "Too many threshold blocks")
+	requireDiagnosticSummary(t, diags, "Extra threshold blocks are ignored")
+	if diags.HasError() {
+		t.Errorf("extra threshold blocks should warn, not fail the plan, got: %v", diags)
+	}
 
 	one := testMonitorV2BasePlan(t, query)
 	diags = nil

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -361,7 +361,7 @@ func (r *monitorV2Resource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"threshold": schema.ListNestedBlock{
-				MarkdownDescription: "Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level.",
+				MarkdownDescription: "Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; a monitor evaluates a single threshold. For several alert levels, a separate monitor can cover each level.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -672,7 +672,7 @@ func validateMonitorV2Config(ctx context.Context, config *monitorV2ResourceModel
 		diags.AddAttributeError(
 			path.Root("threshold"),
 			"Too many threshold blocks",
-			fmt.Sprintf("This resource supports exactly one threshold block, got %d. A monitor evaluates a single threshold; to alert at several levels, create a monitor per level.", n),
+			fmt.Sprintf("This resource supports exactly one threshold block, got %d. A monitor evaluates a single threshold; for several alert levels, a separate monitor can cover each level.", n),
 		)
 	}
 

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -660,8 +660,10 @@ func validateMonitorV2Config(ctx context.Context, config *monitorV2ResourceModel
 	// Surface evaluation_delay parse/range errors at plan time; the result is discarded here.
 	monitorV2EvaluationDelayToSDK(config.Query.EvaluationDelay, diags)
 
-	// The backend evaluates a single threshold per monitor: extra blocks are accepted by the API
-	// and silently ignored, so reject them at plan time rather than let them look configured.
+	// A monitor evaluates a single threshold: extra blocks are accepted by the API and never
+	// reach the alert condition, so say so at plan time instead of letting them look configured.
+	// A warning rather than an error, so upgrading does not break a plan that used to pass; a
+	// future major version can reject them.
 	if n := len(config.Thresholds); n == 0 {
 		diags.AddAttributeError(
 			path.Root("threshold"),
@@ -669,10 +671,10 @@ func validateMonitorV2Config(ctx context.Context, config *monitorV2ResourceModel
 			"This resource requires exactly one threshold block.",
 		)
 	} else if n > 1 {
-		diags.AddAttributeError(
+		diags.AddAttributeWarning(
 			path.Root("threshold"),
-			"Too many threshold blocks",
-			fmt.Sprintf("This resource supports exactly one threshold block, got %d. A monitor evaluates a single threshold; for several alert levels, a separate monitor can cover each level.", n),
+			"Extra threshold blocks are ignored",
+			fmt.Sprintf("This resource supports exactly one threshold block, got %d. A monitor evaluates a single threshold, so only the first block takes effect and the rest are ignored. A future major version will reject them. For several alert levels, a separate monitor can cover each level.", n),
 		)
 	}
 

--- a/internal/provider/resource_monitor_v2.go
+++ b/internal/provider/resource_monitor_v2.go
@@ -361,7 +361,7 @@ func (r *monitorV2Resource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"threshold": schema.ListNestedBlock{
-				MarkdownDescription: "Required. Thresholds that decide when the monitor fires. At least one threshold block must be configured.",
+				MarkdownDescription: "Required. The threshold that decides when the monitor fires. Exactly one threshold block must be configured; the backend evaluates a single threshold per monitor. To alert at several levels, create a monitor per level.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -660,11 +660,19 @@ func validateMonitorV2Config(ctx context.Context, config *monitorV2ResourceModel
 	// Surface evaluation_delay parse/range errors at plan time; the result is discarded here.
 	monitorV2EvaluationDelayToSDK(config.Query.EvaluationDelay, diags)
 
-	if len(config.Thresholds) == 0 {
+	// The backend evaluates a single threshold per monitor: extra blocks are accepted by the API
+	// and silently ignored, so reject them at plan time rather than let them look configured.
+	if n := len(config.Thresholds); n == 0 {
 		diags.AddAttributeError(
 			path.Root("threshold"),
 			"Missing threshold block",
-			"This resource requires at least one threshold block.",
+			"This resource requires exactly one threshold block.",
+		)
+	} else if n > 1 {
+		diags.AddAttributeError(
+			path.Root("threshold"),
+			"Too many threshold blocks",
+			fmt.Sprintf("This resource supports exactly one threshold block, got %d. A monitor evaluates a single threshold; to alert at several levels, create a monitor per level.", n),
 		)
 	}
 


### PR DESCRIPTION
# User description
## Why

A customer asked whether monitors support multiple thresholds. The support AI read the `thresholds` array in the docs and answered yes, with a two-block warning/critical example. They don't: a monitor evaluates one threshold.

In groundcover-private @ `origin/main`:

- `internal/monitors/grafana_alerts_client.go:570` sets the Grafana alert condition to `monitor.Model.Thresholds[0].Name` ("the default condition is the first threshold").
- `internal/monitors/model.go:2467` carries the same note: "default behaviour for now will be to get the first threshold".
- `internal/services/router/api/monitors/monitor_instance_timeline.go:96` reads `Thresholds[0]`.
- The newer spec in `pkg/monitors/model/validate.go:344` rejects extras outright: `multiple thresholds are not yet supported; got %d`.

The list shape is preparation for future multi-threshold support. The product docs are already fixed (groundcover-com/docs#170); this is the same fix on the provider, which Ran flagged.

The provider was not only worded loosely, it enforced the loose wording: `threshold` is a `ListNestedBlock` and `validateMonitorV2Config` only rejected zero, so two blocks planned clean, applied clean, and the backend kept the first and dropped the second silently.

## Changes

- `validateMonitorV2Config` warns at plan time on more than one `threshold` block, and the zero-block message now says "exactly one".
- Schema description reworded from "Thresholds ... At least one threshold block must be configured" to exactly one, with a pointer to creating a monitor per alert level.
- `make generate` refreshed `docs/resources/monitor_v2.md` and `docs/resources/monitor_v2_json.md`; `REFERENCE.md` had the same "One or more threshold definitions" wording by hand.
- Unit test `TestMonitorV2ValidateThresholdCount` covers zero, one, and two blocks.

`groundcover_monitor_v2_json` reuses this schema and `validateMonitorV2Config`, so it is covered by the same change. `groundcover_monitor` (v1) is YAML passthrough with no threshold schema, so it is untouched.

`CHANGELOG.md` **1.22.4**: a patch, since no config that used to plan stops planning.

## Impact on configs that already send more than one threshold

**Alerting does not change, before or after.** Every threshold becomes a Grafana query/expression node (`CreateAlertQueries`), but the alert rule's `Condition` is `Thresholds[0].Name` (`grafana_alerts_client.go:570`). A second block was computed and then read by nobody, so no one was alerted on it and no one stops being alerted on it now.

**Nothing breaks on upgrade.** This is a warning, not an error: `terraform validate` and `plan` still succeed, the extra blocks are still sent, and the stored monitor is unchanged. The message says only the first block takes effect and that a future major version will reject the rest. An earlier revision of this PR failed the plan instead, which would have broken any pipeline holding two blocks, including `terraform plan -destroy`.

When a user acts on the warning and deletes the extra block, the next plan shows a one-time diff dropping it from the API object, then converges. Not a perpetual diff, and not an alerting change.

**How many configs are affected is not established.** Monitor definitions live in the backend's Postgres (`k8s/groundcover/templates/backend/monitors-service`), which for BYOC customers runs in their own cloud, so there is no central table to count from. Per workspace it is a `POST /api/monitors/list` plus a `GET /api/monitors/{uuid}` per monitor, filtered on `(.model.thresholds | length) > 1`.

## Verification

`go test ./internal/provider` passes. Beyond the unit test, I ran the built provider under a `dev_overrides` config through `terraform validate`, which exercises the real plan-time path:

- Two `threshold` blocks on `groundcover_monitor_v2`, and separately on `groundcover_monitor_v2_json`, both raise `Warning: Extra threshold blocks are ignored` and validation still succeeds.
- One `threshold` block validates with no diagnostics. Zero blocks still error.

An earlier revision also had `listvalidator.SizeAtMost(1)` on the block. Framework validators cannot express block cardinality in the published schema anyway (see the thread on `internal/fwschema/block.go:24`), and it emitted a second, generic message for the same mistake, so I dropped it and kept the explanatory diagnostic.

`make lint` was not run: `golangci-lint` isn't installed on this machine. `go vet ./internal/provider` is clean, and CI will lint.

## PR checklist

- [ ] I have written acceptance tests for my changes — unit test instead; per AGENTS.md, validator coverage belongs in unit tests, and this adds no CRUD surface
- [x] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality — no new functionality; existing examples already use one threshold block
- [ ] I have updated the README.md with details of changes — no per-resource list change; `REFERENCE.md` updated instead
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>groundcover_monitor_v2</code> and <code>groundcover_monitor_v2_json</code> validation and documentation to require exactly one threshold while warning that extra blocks are ignored. Extend <code>validateMonitorV2Config</code> and its unit coverage, and refresh generated references and the changelog.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/139?tool=ast&topic=Threshold+documentation>Threshold documentation</a>
        </td><td>Clarify the single-threshold requirement and separate-monitor guidance across generated resource documentation, the provider reference, and release notes.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>REFERENCE.md</li>
<li>docs/resources/monitor_v2.md</li>
<li>docs/resources/monitor_v2_json.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bertin@groundcover.com</td><td>Merge branch &#x27;main&#x27; in...</td><td>September 02, 2026</td></tr>
<tr><td>rantoueg@MacBook-Pro-s...</td><td>docs: fix incorrect se...</td><td>September 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/139?tool=ast&topic=Single+threshold+validation>Single threshold validation</a>
        </td><td>Warn during planning when monitors contain multiple threshold blocks, clarify that only the first threshold affects alert evaluation, and preserve compatibility by allowing the configuration with a warning.<details><summary>Modified files (2)</summary><ul><li>internal/provider/resource_monitor_test.go</li>
<li>internal/provider/resource_monitor_v2.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danny.shmueli@groundco...</td><td>Pin the whole threshol...</td><td>September 01, 2026</td></tr>
<tr><td>sathwick-p</td><td>fix: prevent duration ...</td><td>August 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/139?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>