### PR TITLE
docs: BE-3071 refresh database monitoring examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.4
+
+* Updated the `groundcover_dataintegration` PostgreSQL and ClickHouse database-monitoring examples with built-in health metrics and query-statistics collection.
+
 ## 1.22.3
 
 * Fixed normalization of day/week relative time ranges in `groundcover_monitor_v2` and `groundcover_monitor_v2_json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.22.4
 
-* Updated the `groundcover_dataintegration` PostgreSQL and ClickHouse database-monitoring examples with built-in health metrics and query-statistics collection.
+* Updated the `groundcover_dataintegration` PostgreSQL and ClickHouse database-monitoring examples with built-in health metrics and query-statistics collection. Custom metric queries remain supported but are intentionally no longer shown in these Phase 1 examples.
 * `groundcover_monitor_v2` and `groundcover_monitor_v2_json` now warn at plan time when more than one `threshold` block is configured. A monitor evaluates a single threshold, so only the first block takes effect and the rest are ignored; a future major version will reject them. The schema description and docs said "at least one threshold block", which read as multi-threshold support
 * Fixed an incorrect comment in the `groundcover_dataintegration` example: the ClickHouse and PostgreSQL (`clickhousedbm` / `postgresqldbm`) password examples use a `secretRef::k8s::` reference, which points at an existing Kubernetes secret in the cluster running the integration, but the comment told users to create it with the `groundcover_secret` resource. `groundcover_secret` produces a `secretRef::store::<id>` reference, not a `secretRef::k8s::` one
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Basic usage examples can be found in the `examples/` directory:
 *   **Dashboard Resource:** [`examples/resources/groundcover_dashboard/resource.tf`](./examples/resources/groundcover_dashboard/resource.tf)
     *   Demonstrates how to create and manage dashboards with customizable widgets and layouts.
 *   **Data Integration Resource:** [`examples/resources/groundcover_dataintegration/resource.tf`](./examples/resources/groundcover_dataintegration/resource.tf)
-    *   Demonstrates how to create and manage data integrations.
+    *   Demonstrates how to create and manage data integrations, including PostgreSQL and ClickHouse health metrics and query-statistics collection.
 *   **Silence Resource:** [`examples/resources/groundcover_silence/resource.tf`](./examples/resources/groundcover_silence/resource.tf)
     *   Demonstrates how to create and manage alert silences with time windows and matchers.
 *   **Recurring Silence Resource:** [`examples/resources/groundcover_recurring_silence/resource.tf`](./examples/resources/groundcover_recurring_silence/resource.tf)

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -495,18 +495,6 @@ EOT
 # Example: ClickHouse database monitoring
 # The integration user needs SELECT on system.*. Cluster mode also requires:
 # GRANT REMOTE ON *.* TO groundcover;
-variable "clickhouse_dbm_password" {
-  type        = string
-  description = "Password for the ClickHouse database-monitoring user"
-  sensitive   = true
-}
-
-resource "groundcover_secret" "clickhouse_dbm_password" {
-  name    = "clickhouse-dbm-password"
-  type    = "password"
-  content = var.clickhouse_dbm_password
-}
-
 resource "groundcover_dataintegration" "clickhouse_dbm" {
   type      = "clickhousedbm"
   is_paused = false
@@ -527,10 +515,10 @@ resource "groundcover_dataintegration" "clickhouse_dbm" {
 
     authentication = {
       basicAuth = {
-        username = "groundcover"
-        # The secret resource ID is already a secretRef::store::... value.
-        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
-        password = groundcover_secret.clickhouse_dbm_password.id
+        username = "default"
+
+        # use the groundcover_secret resource to create a secret
+        password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
       }
     }
 
@@ -637,18 +625,6 @@ EOT
 # 2. Run CREATE EXTENSION IF NOT EXISTS pg_stat_statements; in the monitored database.
 # 3. Run GRANT pg_monitor TO groundcover; for capability-sensitive health metrics.
 # 4. Enable track_io_timing for PostgreSQL I/O timing metrics.
-variable "postgresql_dbm_password" {
-  type        = string
-  description = "Password for the PostgreSQL database-monitoring user"
-  sensitive   = true
-}
-
-resource "groundcover_secret" "postgresql_dbm_password" {
-  name    = "postgresql-dbm-password"
-  type    = "password"
-  content = var.postgresql_dbm_password
-}
-
 resource "groundcover_dataintegration" "postgresql_dbm" {
   type      = "postgresqldbm"
   is_paused = false
@@ -668,10 +644,10 @@ resource "groundcover_dataintegration" "postgresql_dbm" {
 
     authentication = {
       basicAuth = {
-        username = "groundcover"
-        # The secret resource ID is already a secretRef::store::... value.
-        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
-        password = groundcover_secret.postgresql_dbm_password.id
+        username = "postgres"
+
+        # use the groundcover_secret resource to create a secret
+        password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
       }
     }
 

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -492,69 +492,82 @@ EOT
   is_paused = false
 }
 
-# Example: ClickHouse - Query Log & Custom Metrics
-resource "groundcover_dataintegration" "clickhouse_demo" {
+# Example: ClickHouse database monitoring
+# The integration user needs SELECT on system.*. Cluster mode also requires:
+# GRANT REMOTE ON *.* TO groundcover;
+variable "clickhouse_dbm_password" {
+  type        = string
+  description = "Password for the ClickHouse database-monitoring user"
+  sensitive   = true
+}
+
+resource "groundcover_secret" "clickhouse_dbm_password" {
+  name    = "clickhouse-dbm-password"
+  type    = "password"
+  content = var.clickhouse_dbm_password
+}
+
+resource "groundcover_dataintegration" "clickhouse_dbm" {
   type      = "clickhousedbm"
   is_paused = false
 
   config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "production-clickhouse"
+
+    host         = "clickhouse.example.com"
+    port         = 9440
+    protocol     = "native"
+    database     = "default"
+    secure       = true
+    skipVerify   = false
+    dialTimeout  = "10s"
+    queryTimeout = "30s"
+
     authentication = {
       basicAuth = {
-        username = "default"
-
-        # use the groundcover_secret resource to create a secret
-        password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
+        username = "groundcover"
+        # The secret resource ID is already a secretRef::store::... value.
+        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
+        password = groundcover_secret.clickhouse_dbm_password.id
       }
     }
 
-    clusterMode = true          # true if your ClickHouse is running in cluster mode; false for a single node
-    clusterName = "clustername" # the name of the cluster. Relevant if clusterMode=true
-    database    = "your clickhouse db name"
-    dialTimeout = "10s"
-    enabled     = true
-    host        = "your clickhouse host details"
-    name        = "clickhouse demo integration"
-    port        = 9000
-    skipVerify  = false
-    version     = 1
+    clusterMode = true
+    clusterName = "default"
 
     labelSettings = {
       extraLabels = {
-        env = "prod"
+        environment = "production"
+        team        = "database-platform"
       }
     }
 
-    # Optional - generate metrics from custom sql's.
-    # metricsColumns - the list of metrics to be created
-    customMetricQueries = {
-      collectionInterval = "5m"
-
-      queries = [
-        {
-          name         = "test query"
-          metricPrefix = "gc_clickhouse"
-          extraLabels  = {}
-
-          metricsColumns = [
-            {
-              name       = "accounts_count"
-              metricName = "total"
-              type       = "counter"
-            }
-          ]
-
-          query = <<EOT
-SELECT
-    tier,
-    count() as accounts_count
-FROM my_accounts
-GROUP BY tier
-EOT
-        }
-      ]
+    # Built-in health metrics are Prometheus metrics. The top-level interval
+    # controls their collection cadence. Capacity and events use curated
+    # defaults when their optional include lists are omitted.
+    interval        = "1m"
+    ignoreDatabases = ["system", "information_schema"]
+    healthMetrics = {
+      enabled = true
+      topN    = 50
+      groups = {
+        parts         = { enabled = true }
+        merges        = { enabled = true }
+        mutations     = { enabled = true }
+        replication   = { enabled = true }
+        connections   = { enabled = true }
+        capacity      = { enabled = true }
+        events        = { enabled = true }
+        detachedParts = { enabled = true }
+        tableSizes    = { enabled = true }
+        viewRefreshes = { enabled = true }
+        dictionaries  = { enabled = true }
+      }
     }
 
-    # Optional - fetch query performance traces.
+    # Query logs are collected as traces, independently of health metrics.
     tables = {
       queryLog = {
         enabled       = true
@@ -618,68 +631,82 @@ EOT
   is_paused = false
 }
 
-# Example: PostgreSQL - Slow Queries & Custom Metrics
-resource "groundcover_dataintegration" "postgresql_demo" {
+# Example: PostgreSQL database monitoring
+# Before applying:
+# 1. Add pg_stat_statements to shared_preload_libraries and restart PostgreSQL.
+# 2. Run CREATE EXTENSION IF NOT EXISTS pg_stat_statements; in the monitored database.
+# 3. Run GRANT pg_monitor TO groundcover; for capability-sensitive health metrics.
+# 4. Enable track_io_timing for PostgreSQL I/O timing metrics.
+variable "postgresql_dbm_password" {
+  type        = string
+  description = "Password for the PostgreSQL database-monitoring user"
+  sensitive   = true
+}
+
+resource "groundcover_secret" "postgresql_dbm_password" {
+  name    = "postgresql-dbm-password"
+  type    = "password"
+  content = var.postgresql_dbm_password
+}
+
+resource "groundcover_dataintegration" "postgresql_dbm" {
   type      = "postgresqldbm"
   is_paused = false
 
   config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "production-postgresql"
+
+    host         = "postgresql.example.com"
+    port         = 5432
+    database     = "postgres"
+    secure       = true
+    skipVerify   = false
+    dialTimeout  = "10s"
+    queryTimeout = "30s"
+
     authentication = {
       basicAuth = {
-        username = "postgres"
-
-        # use the groundcover_secret resource to create a secret
-        password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
+        username = "groundcover"
+        # The secret resource ID is already a secretRef::store::... value.
+        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
+        password = groundcover_secret.postgresql_dbm_password.id
       }
     }
-
-    database = "your postgresql db name"
-
-    dialTimeout = "10s"
-    enabled     = true
-    host        = "your postgres host details"
-    name        = "postgres demo integration"
-    port        = 5432
-    secure      = true
-    skipVerify  = false
-    version     = 1
 
     labelSettings = {
       extraLabels = {
-        env = "prod"
+        environment = "production"
+        team        = "database-platform"
       }
     }
 
-    # Optional - generate metrics from custom sql's.
-    # metricsColumns - the list of metrics to be created
-    customMetricQueries = {
-      collectionInterval = "5m"
-
-      queries = [
-        {
-          name         = "test query"
-          metricPrefix = "gc_postgres"
-
-          metricsColumns = [
-            {
-              name       = "accounts_count"
-              metricName = "total"
-              type       = "counter"
-            }
-          ]
-
-          query = <<EOT
-SELECT
-    tier,
-    count(*) as accounts_count
-FROM my_accounts
-GROUP BY tier
-EOT
-        }
-      ]
+    # Built-in health metrics are Prometheus metrics. Groups that are not
+    # supported by the server version, settings, grants, or current
+    # primary/standby role are gated automatically.
+    interval        = "1m"
+    ignoreDatabases = ["template0", "template1", "rdsadmin"]
+    healthMetrics = {
+      enabled = true
+      groups = {
+        connections   = { enabled = true }
+        replication   = { enabled = true }
+        standby       = { enabled = true }
+        databaseStats = { enabled = true }
+        wraparound    = { enabled = true }
+        databaseSize  = { enabled = true }
+        conflicts     = { enabled = true }
+        checkpoints   = { enabled = true }
+        wal           = { enabled = true }
+        archiver      = { enabled = true }
+        io            = { enabled = true }
+        instance      = { enabled = true }
+        locks         = { enabled = true }
+      }
     }
 
-    # Optional - fetch query performance traces.
+    # pg_stat_statements rows are collected as traces, independently of health metrics.
     tables = {
       pgStatStatements = {
         enabled       = true
@@ -832,9 +859,9 @@ output "rediscloud_dataintegration_id" {
   value       = groundcover_dataintegration.rediscloud_example.id
 }
 
-output "clickhouse_demo_dataintegration_id" {
-  description = "The ID of the ClickHouse Query Log & Custom Metrics data integration"
-  value       = groundcover_dataintegration.clickhouse_demo.id
+output "clickhouse_dbm_dataintegration_id" {
+  description = "The ID of the ClickHouse database-monitoring data integration"
+  value       = groundcover_dataintegration.clickhouse_dbm.id
 }
 
 output "clickhouse_system_metrics_dataintegration_id" {
@@ -842,9 +869,9 @@ output "clickhouse_system_metrics_dataintegration_id" {
   value       = groundcover_dataintegration.clickhouse_system_metrics_example.id
 }
 
-output "postgresql_demo_dataintegration_id" {
-  description = "The ID of the PostgreSQL Slow Queries & Custom Metrics data integration"
-  value       = groundcover_dataintegration.postgresql_demo.id
+output "postgresql_dbm_dataintegration_id" {
+  description = "The ID of the PostgreSQL database-monitoring data integration"
+  value       = groundcover_dataintegration.postgresql_dbm.id
 }
 
 output "postgresql_system_metrics_dataintegration_id" {

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -477,69 +477,82 @@ EOT
   is_paused = false
 }
 
-# Example: ClickHouse - Query Log & Custom Metrics
-resource "groundcover_dataintegration" "clickhouse_demo" {
+# Example: ClickHouse database monitoring
+# The integration user needs SELECT on system.*. Cluster mode also requires:
+# GRANT REMOTE ON *.* TO groundcover;
+variable "clickhouse_dbm_password" {
+  type        = string
+  description = "Password for the ClickHouse database-monitoring user"
+  sensitive   = true
+}
+
+resource "groundcover_secret" "clickhouse_dbm_password" {
+  name    = "clickhouse-dbm-password"
+  type    = "password"
+  content = var.clickhouse_dbm_password
+}
+
+resource "groundcover_dataintegration" "clickhouse_dbm" {
   type      = "clickhousedbm"
   is_paused = false
 
   config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "production-clickhouse"
+
+    host         = "clickhouse.example.com"
+    port         = 9440
+    protocol     = "native"
+    database     = "default"
+    secure       = true
+    skipVerify   = false
+    dialTimeout  = "10s"
+    queryTimeout = "30s"
+
     authentication = {
       basicAuth = {
-        username = "default"
-
-        # use the groundcover_secret resource to create a secret
-        password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
+        username = "groundcover"
+        # The secret resource ID is already a secretRef::store::... value.
+        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
+        password = groundcover_secret.clickhouse_dbm_password.id
       }
     }
 
-    clusterMode = true          # true if your ClickHouse is running in cluster mode; false for a single node
-    clusterName = "clustername" # the name of the cluster. Relevant if clusterMode=true
-    database    = "your clickhouse db name"
-    dialTimeout = "10s"
-    enabled     = true
-    host        = "your clickhouse host details"
-    name        = "clickhouse demo integration"
-    port        = 9000
-    skipVerify  = false
-    version     = 1
+    clusterMode = true
+    clusterName = "default"
 
     labelSettings = {
       extraLabels = {
-        env = "prod"
+        environment = "production"
+        team        = "database-platform"
       }
     }
 
-    # Optional - generate metrics from custom sql's.
-    # metricsColumns - the list of metrics to be created
-    customMetricQueries = {
-      collectionInterval = "5m"
-
-      queries = [
-        {
-          name         = "test query"
-          metricPrefix = "gc_clickhouse"
-          extraLabels  = {}
-
-          metricsColumns = [
-            {
-              name       = "accounts_count"
-              metricName = "total"
-              type       = "counter"
-            }
-          ]
-
-          query = <<EOT
-SELECT
-    tier,
-    count() as accounts_count
-FROM my_accounts
-GROUP BY tier
-EOT
-        }
-      ]
+    # Built-in health metrics are Prometheus metrics. The top-level interval
+    # controls their collection cadence. Capacity and events use curated
+    # defaults when their optional include lists are omitted.
+    interval        = "1m"
+    ignoreDatabases = ["system", "information_schema"]
+    healthMetrics = {
+      enabled = true
+      topN    = 50
+      groups = {
+        parts         = { enabled = true }
+        merges        = { enabled = true }
+        mutations     = { enabled = true }
+        replication   = { enabled = true }
+        connections   = { enabled = true }
+        capacity      = { enabled = true }
+        events        = { enabled = true }
+        detachedParts = { enabled = true }
+        tableSizes    = { enabled = true }
+        viewRefreshes = { enabled = true }
+        dictionaries  = { enabled = true }
+      }
     }
 
-    # Optional - fetch query performance traces.
+    # Query logs are collected as traces, independently of health metrics.
     tables = {
       queryLog = {
         enabled       = true
@@ -603,68 +616,82 @@ EOT
   is_paused = false
 }
 
-# Example: PostgreSQL - Slow Queries & Custom Metrics
-resource "groundcover_dataintegration" "postgresql_demo" {
+# Example: PostgreSQL database monitoring
+# Before applying:
+# 1. Add pg_stat_statements to shared_preload_libraries and restart PostgreSQL.
+# 2. Run CREATE EXTENSION IF NOT EXISTS pg_stat_statements; in the monitored database.
+# 3. Run GRANT pg_monitor TO groundcover; for capability-sensitive health metrics.
+# 4. Enable track_io_timing for PostgreSQL I/O timing metrics.
+variable "postgresql_dbm_password" {
+  type        = string
+  description = "Password for the PostgreSQL database-monitoring user"
+  sensitive   = true
+}
+
+resource "groundcover_secret" "postgresql_dbm_password" {
+  name    = "postgresql-dbm-password"
+  type    = "password"
+  content = var.postgresql_dbm_password
+}
+
+resource "groundcover_dataintegration" "postgresql_dbm" {
   type      = "postgresqldbm"
   is_paused = false
 
   config = jsonencode({
+    version = 1
+    enabled = true
+    name    = "production-postgresql"
+
+    host         = "postgresql.example.com"
+    port         = 5432
+    database     = "postgres"
+    secure       = true
+    skipVerify   = false
+    dialTimeout  = "10s"
+    queryTimeout = "30s"
+
     authentication = {
       basicAuth = {
-        username = "postgres"
-
-        # use the groundcover_secret resource to create a secret
-        password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
+        username = "groundcover"
+        # The secret resource ID is already a secretRef::store::... value.
+        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
+        password = groundcover_secret.postgresql_dbm_password.id
       }
     }
-
-    database = "your postgresql db name"
-
-    dialTimeout = "10s"
-    enabled     = true
-    host        = "your postgres host details"
-    name        = "postgres demo integration"
-    port        = 5432
-    secure      = true
-    skipVerify  = false
-    version     = 1
 
     labelSettings = {
       extraLabels = {
-        env = "prod"
+        environment = "production"
+        team        = "database-platform"
       }
     }
 
-    # Optional - generate metrics from custom sql's.
-    # metricsColumns - the list of metrics to be created
-    customMetricQueries = {
-      collectionInterval = "5m"
-
-      queries = [
-        {
-          name         = "test query"
-          metricPrefix = "gc_postgres"
-
-          metricsColumns = [
-            {
-              name       = "accounts_count"
-              metricName = "total"
-              type       = "counter"
-            }
-          ]
-
-          query = <<EOT
-SELECT
-    tier,
-    count(*) as accounts_count
-FROM my_accounts
-GROUP BY tier
-EOT
-        }
-      ]
+    # Built-in health metrics are Prometheus metrics. Groups that are not
+    # supported by the server version, settings, grants, or current
+    # primary/standby role are gated automatically.
+    interval        = "1m"
+    ignoreDatabases = ["template0", "template1", "rdsadmin"]
+    healthMetrics = {
+      enabled = true
+      groups = {
+        connections   = { enabled = true }
+        replication   = { enabled = true }
+        standby       = { enabled = true }
+        databaseStats = { enabled = true }
+        wraparound    = { enabled = true }
+        databaseSize  = { enabled = true }
+        conflicts     = { enabled = true }
+        checkpoints   = { enabled = true }
+        wal           = { enabled = true }
+        archiver      = { enabled = true }
+        io            = { enabled = true }
+        instance      = { enabled = true }
+        locks         = { enabled = true }
+      }
     }
 
-    # Optional - fetch query performance traces.
+    # pg_stat_statements rows are collected as traces, independently of health metrics.
     tables = {
       pgStatStatements = {
         enabled       = true
@@ -817,9 +844,9 @@ output "rediscloud_dataintegration_id" {
   value       = groundcover_dataintegration.rediscloud_example.id
 }
 
-output "clickhouse_demo_dataintegration_id" {
-  description = "The ID of the ClickHouse Query Log & Custom Metrics data integration"
-  value       = groundcover_dataintegration.clickhouse_demo.id
+output "clickhouse_dbm_dataintegration_id" {
+  description = "The ID of the ClickHouse database-monitoring data integration"
+  value       = groundcover_dataintegration.clickhouse_dbm.id
 }
 
 output "clickhouse_system_metrics_dataintegration_id" {
@@ -827,9 +854,9 @@ output "clickhouse_system_metrics_dataintegration_id" {
   value       = groundcover_dataintegration.clickhouse_system_metrics_example.id
 }
 
-output "postgresql_demo_dataintegration_id" {
-  description = "The ID of the PostgreSQL Slow Queries & Custom Metrics data integration"
-  value       = groundcover_dataintegration.postgresql_demo.id
+output "postgresql_dbm_dataintegration_id" {
+  description = "The ID of the PostgreSQL database-monitoring data integration"
+  value       = groundcover_dataintegration.postgresql_dbm.id
 }
 
 output "postgresql_system_metrics_dataintegration_id" {

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -480,18 +480,6 @@ EOT
 # Example: ClickHouse database monitoring
 # The integration user needs SELECT on system.*. Cluster mode also requires:
 # GRANT REMOTE ON *.* TO groundcover;
-variable "clickhouse_dbm_password" {
-  type        = string
-  description = "Password for the ClickHouse database-monitoring user"
-  sensitive   = true
-}
-
-resource "groundcover_secret" "clickhouse_dbm_password" {
-  name    = "clickhouse-dbm-password"
-  type    = "password"
-  content = var.clickhouse_dbm_password
-}
-
 resource "groundcover_dataintegration" "clickhouse_dbm" {
   type      = "clickhousedbm"
   is_paused = false
@@ -512,10 +500,10 @@ resource "groundcover_dataintegration" "clickhouse_dbm" {
 
     authentication = {
       basicAuth = {
-        username = "groundcover"
-        # The secret resource ID is already a secretRef::store::... value.
-        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
-        password = groundcover_secret.clickhouse_dbm_password.id
+        username = "default"
+
+        # use the groundcover_secret resource to create a secret
+        password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
       }
     }
 
@@ -622,18 +610,6 @@ EOT
 # 2. Run CREATE EXTENSION IF NOT EXISTS pg_stat_statements; in the monitored database.
 # 3. Run GRANT pg_monitor TO groundcover; for capability-sensitive health metrics.
 # 4. Enable track_io_timing for PostgreSQL I/O timing metrics.
-variable "postgresql_dbm_password" {
-  type        = string
-  description = "Password for the PostgreSQL database-monitoring user"
-  sensitive   = true
-}
-
-resource "groundcover_secret" "postgresql_dbm_password" {
-  name    = "postgresql-dbm-password"
-  type    = "password"
-  content = var.postgresql_dbm_password
-}
-
 resource "groundcover_dataintegration" "postgresql_dbm" {
   type      = "postgresqldbm"
   is_paused = false
@@ -653,10 +629,10 @@ resource "groundcover_dataintegration" "postgresql_dbm" {
 
     authentication = {
       basicAuth = {
-        username = "groundcover"
-        # The secret resource ID is already a secretRef::store::... value.
-        # An existing secretRef::k8s::<namespace>::<secret>::<key> can be used instead.
-        password = groundcover_secret.postgresql_dbm_password.id
+        username = "postgres"
+
+        # use the groundcover_secret resource to create a secret
+        password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
       }
     }
 


### PR DESCRIPTION
# User description
## Description

- Add the shipped Phase 1 health-metric configuration to the existing PostgreSQL and ClickHouse `groundcover_dataintegration` examples.
- Document the health groups, collection intervals, database exclusions, prerequisites, and capability auto-gating while preserving the existing authentication examples and secret references.
- Regenerate the provider resource documentation and update the README and changelog.

## Testing

- `terraform fmt -check examples/resources/groundcover_dataintegration/resource.tf`
- `terraform validate`
- `go test ./internal/provider -v`
- `golangci-lint` v2.9.0: 0 issues

## Checklist

- [ ] I have written acceptance tests for my changes (documentation-only change)
- [x] I have run `make generate` to update generated docs
- [x] I have added examples demonstrating the new functionality
- [x] I have updated the README.md with details of changes
- [x] I have updated the CHANGELOG.md file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refresh the <code>groundcover_dataintegration</code> Terraform examples and generated documentation to show production-ready PostgreSQL and ClickHouse database monitoring. Add built-in health metrics, query-statistics collection, prerequisites, capability gating, connection settings, labels, and secret-reference conventions while updating project guidance and release notes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/140?tool=ast&topic=Database+Examples>Database Examples</a>
        </td><td>Add runnable PostgreSQL and ClickHouse configurations with built-in health-metric groups, collection intervals, exclusions, query-statistics traces, connection settings, cluster options, labels, and prerequisite guidance.<details><summary>Modified files (2)</summary><ul><li>docs/resources/dataintegration.md</li>
<li>examples/resources/groundcover_dataintegration/resource.tf</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bar.amsalem@groundcove...</td><td>Merge remote-tracking ...</td><td>September 02, 2026</td></tr>
<tr><td>rantoueg@MacBook-Pro-s...</td><td>docs: fix incorrect se...</td><td>September 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/140?tool=ast&topic=Project+Documentation>Project Documentation</a>
        </td><td>Document the refreshed database-monitoring examples in project navigation and release history, including the continued support for custom metric queries and corrected secret-reference guidance.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>bar.amsalem@groundcove...</td><td>docs: clarify custom q...</td><td>September 02, 2026</td></tr>
<tr><td>bertin@groundcover.com</td><td>Merge branch &#x27;main&#x27; in...</td><td>September 02, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/140?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>