### PR TITLE
docs: fix incorrect secret comment in dataintegration k8s examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.4
+
+* Fixed an incorrect comment in the `groundcover_dataintegration` example: the ClickHouse and PostgreSQL (`clickhousedbm` / `postgresqldbm`) password examples use a `secretRef::k8s::` reference, which points at an existing Kubernetes secret in the cluster running the integration, but the comment told users to create it with the `groundcover_secret` resource. `groundcover_secret` produces a `secretRef::store::<id>` reference, not a `secretRef::k8s::` one
+
 ## 1.22.3
 
 * Fixed normalization of day/week relative time ranges in `groundcover_monitor_v2` and `groundcover_monitor_v2_json`.

--- a/docs/resources/dataintegration.md
+++ b/docs/resources/dataintegration.md
@@ -502,7 +502,10 @@ resource "groundcover_dataintegration" "clickhouse_demo" {
       basicAuth = {
         username = "default"
 
-        # use the groundcover_secret resource to create a secret
+        # Use this form when the integration runs from your own cluster: it refers to an
+        # existing Kubernetes secret, as secretRef::k8s::<namespace>::<secret-name>::<key>.
+        # Create that secret in the cluster yourself. The groundcover_secret resource is not
+        # used here - it produces a secretRef::store::<id> reference instead.
         password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
       }
     }
@@ -628,7 +631,10 @@ resource "groundcover_dataintegration" "postgresql_demo" {
       basicAuth = {
         username = "postgres"
 
-        # use the groundcover_secret resource to create a secret
+        # Use this form when the integration runs from your own cluster: it refers to an
+        # existing Kubernetes secret, as secretRef::k8s::<namespace>::<secret-name>::<key>.
+        # Create that secret in the cluster yourself. The groundcover_secret resource is not
+        # used here - it produces a secretRef::store::<id> reference instead.
         password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
       }
     }

--- a/examples/resources/groundcover_dataintegration/resource.tf
+++ b/examples/resources/groundcover_dataintegration/resource.tf
@@ -487,7 +487,10 @@ resource "groundcover_dataintegration" "clickhouse_demo" {
       basicAuth = {
         username = "default"
 
-        # use the groundcover_secret resource to create a secret
+        # Use this form when the integration runs from your own cluster: it refers to an
+        # existing Kubernetes secret, as secretRef::k8s::<namespace>::<secret-name>::<key>.
+        # Create that secret in the cluster yourself. The groundcover_secret resource is not
+        # used here - it produces a secretRef::store::<id> reference instead.
         password = "secretRef::k8s::groundcover::groundcover-clickhouse::admin-password"
       }
     }
@@ -613,7 +616,10 @@ resource "groundcover_dataintegration" "postgresql_demo" {
       basicAuth = {
         username = "postgres"
 
-        # use the groundcover_secret resource to create a secret
+        # Use this form when the integration runs from your own cluster: it refers to an
+        # existing Kubernetes secret, as secretRef::k8s::<namespace>::<secret-name>::<key>.
+        # Create that secret in the cluster yourself. The groundcover_secret resource is not
+        # used here - it produces a secretRef::store::<id> reference instead.
         password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
       }
     }


### PR DESCRIPTION
# User description
## What

The `clickhousedbm` and `postgresqldbm` examples in `groundcover_dataintegration` set their password to a `secretRef::k8s::` reference:

```hcl
password = "secretRef::k8s::groundcover::groundcover-postgresql::admin-password"
```

but the comment above told users to create that secret with the `groundcover_secret` resource. That is wrong. The two prefixes route to different stores:

| Prefix | Store | Created by |
|---|---|---|
| `secretRef::k8s::<namespace>::<secret-name>::<key>` | `K8sSecretStore` | an existing Kubernetes secret in the cluster |
| `secretRef::store::<hashed-uuid>` | `FleetClientStore` (Fleet Manager) | the `groundcover_secret` resource |

`groundcover_secret` produces a `secretRef::store::<id>`, never a `secretRef::k8s::`. The `k8s` form is what you use when the integration runs from your own cluster.

## Change

Both occurrences now read:

```hcl
# Use this form when the integration runs from your own cluster: it refers to an
# existing Kubernetes secret, as secretRef::k8s::<namespace>::<secret-name>::<key>.
# Create that secret in the cluster yourself. The groundcover_secret resource is not
# used here - it produces a secretRef::store::<id> reference instead.
```

Edited in `examples/resources/groundcover_dataintegration/resource.tf`; `docs/resources/dataintegration.md` is the regenerated output.

## Scope

All 16 `secretRef` occurrences in `examples/` were audited against their surrounding comments. The other 14 use `secretRef::store::` and their `groundcover_secret` references are correct, including three in this same file — left untouched.

## Checklist

- [ ] I have written acceptance tests for my changes — n/a, comment-only change to an example
- [x] I have run `make generate` to update generated docs
- [ ] I have added examples demonstrating the new functionality — n/a, no new functionality
- [ ] I have updated the README.md with details of changes — n/a, README carries no secret-ref wording and the per-resource lists are unaffected
- [x] I have updated the CHANGELOG.md file

`CHANGELOG.md` gets a new `1.22.4` section: the top section `1.22.3` is already tagged, so there was no unreleased section to append to, and a doc-only change is a patch bump.

## Note for reviewers regenerating docs

Running `make generate` with a Terraform CLI older than 1.11 also rewrites `docs/resources/secret.md`, stripping the write-only annotation from `content`. That is a toolchain artifact, not a real change — `resource_secret.go` does set `WriteOnly: true`, but `tfplugindocs` sources the schema through the Terraform CLI and write-only arguments only exist in Terraform 1.11+. That file is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the Kubernetes secret guidance for <code>clickhousedbm</code> and <code>postgresqldbm</code> in the <code>groundcover_dataintegration</code> examples. Update the generated dataintegration documentation and changelog to distinguish <code>secretRef::k8s::</code> references, resolved from existing cluster secrets, from <code>groundcover_secret</code> resources that produce <code>secretRef::store::&lt;id&gt;</code> references.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/141?tool=ast&topic=Release+notes>Release notes</a>
        </td><td>Record the documentation correction in the <code>1.22.4</code> release notes.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/groundcover-com/terraform-provider-groundcover/141?tool=ast&topic=Kubernetes+secrets>Kubernetes secrets</a>
        </td><td>Correct the ClickHouse and PostgreSQL integration examples to instruct users to provision existing Kubernetes secrets for <code>secretRef::k8s::</code> passwords, and regenerate the corresponding documentation.<details><summary>Modified files (2)</summary><ul><li>docs/resources/dataintegration.md</li>
<li>examples/resources/groundcover_dataintegration/resource.tf</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/groundcover-com/terraform-provider-groundcover/141?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>